### PR TITLE
Introduce `StarknetState` and new Transaction Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,6 @@ tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["env-filter", "fmt", "std"]}
 tokio = { version = "1.15.0", features = ["full"] }
 uuid = { version = "1.2.1", features = ["v4"] }
-starknet-rs = {git = "https://github.com/lambdaclass/starknet_in_rust"}
+starknet-rs = { git = "https://github.com/lambdaclass/starknet_in_rust", branch= "publish-structs" }
 # This was copied from starkent_in_rust/Cargo.toml as it seems it is missing an export for it
 felt = { git = "https://github.com/lambdaclass/cairo-rs", package = "cairo-felt", rev = "8dba86dbec935fa04a255e2edf3d5d184950fa22" }

--- a/src/abci/application.rs
+++ b/src/abci/application.rs
@@ -6,9 +6,9 @@ use std::{
 use lib::{Transaction, TransactionType};
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
-use starknet_rs::definitions::general_config::StarknetGeneralConfig;
 use tendermint_abci::Application;
 use tendermint_proto::abci;
+use starknet_rs::testing::starknet_state::StarknetState;
 
 use tracing::{debug, info};
 
@@ -19,9 +19,12 @@ use tracing::{debug, info};
 #[derive(Debug, Clone)]
 pub struct CairoApp {
     hasher: Arc<Mutex<Sha256>>,
-    starknet: StarknetGeneralConfig
+    starknet_state: StarknetState
 }
 
+// because we don't get a `&mut self` in the ABCI API, we opt to have a mod-level variable
+// and because beginblock, endblock and deliver_tx all happen in the same thread, this is safe to do 
+// an alternative would be Arc<Mutex<>>, but we want to avoid extra-overhead of locks for the benchmark's sake
 static mut TRANSACTIONS: usize = 0;
 static mut TIMER: Lazy<Instant> = Lazy::new(Instant::now);
 
@@ -87,6 +90,9 @@ impl Application for CairoApp {
                     function, program_name
                 );
             }
+            TransactionType::Declare => todo!(),
+            TransactionType::Deploy => todo!(),
+            TransactionType::Invoke => todo!(),
         }
 
         abci::ResponseCheckTx {
@@ -98,6 +104,7 @@ impl Application for CairoApp {
     /// Used to store current proposer and the previous block's voters to assign fees and coinbase
     /// credits when the block is committed.
     fn begin_block(&self, _request: abci::RequestBeginBlock) -> abci::ResponseBeginBlock {
+        // because begin_block, [deliver_tx] and end_block/commit are on the same thread, this is safe to do (see declaration of statics)
         unsafe {
             TRANSACTIONS = 0;
 
@@ -126,6 +133,7 @@ impl Application for CairoApp {
             .compute_and_hash()
             .map(|x| x == tx.transaction_hash);
 
+        // because begin_block, [deliver_tx] and end_block/commit are on the same thread, this is safe to do (see declaration of statics)
         unsafe {
             TRANSACTIONS += 1;
         }
@@ -165,6 +173,9 @@ impl Application for CairoApp {
                         };
                         events.push(function_event);
                     }
+                    TransactionType::Declare => todo!(),
+                    TransactionType::Deploy => todo!(),
+                    TransactionType::Invoke => todo!(),
                 }
 
                 abci::ResponseDeliverTx {
@@ -192,6 +203,7 @@ impl Application for CairoApp {
     /// For details about validator set update semantics see:
     /// https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/apps.md#endblock
     fn end_block(&self, _request: abci::RequestEndBlock) -> abci::ResponseEndBlock {
+        // because begin_block, [deliver_tx] and end_block/commit are on the same thread, this is safe to do (see declaration of statics)
         unsafe {
             info!(
                 "Committing block with {} transactions in {} ms. TPS: {}",
@@ -243,9 +255,13 @@ impl Application for CairoApp {
 impl CairoApp {
     /// Constructor.
     pub fn new() -> Self {
-        Self {
+        let new_state = Self {
             hasher: Arc::new(Mutex::new(Sha256::new())),
-        }
+            starknet_state: StarknetState::new(None)
+        };
+
+        info!("Starting with Starknet State: {:?}", new_state.starknet_state);
+        new_state
     }
 }
 

--- a/src/abci/application.rs
+++ b/src/abci/application.rs
@@ -6,6 +6,7 @@ use std::{
 use lib::{Transaction, TransactionType};
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
+use starknet_rs::definitions::general_config::StarknetGeneralConfig;
 use tendermint_abci::Application;
 use tendermint_proto::abci;
 
@@ -18,6 +19,7 @@ use tracing::{debug, info};
 #[derive(Debug, Clone)]
 pub struct CairoApp {
     hasher: Arc<Mutex<Sha256>>,
+    starknet: StarknetGeneralConfig
 }
 
 static mut TRANSACTIONS: usize = 0;

--- a/src/abci/application.rs
+++ b/src/abci/application.rs
@@ -6,9 +6,9 @@ use std::{
 use lib::{Transaction, TransactionType};
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
+use starknet_rs::testing::starknet_state::StarknetState;
 use tendermint_abci::Application;
 use tendermint_proto::abci;
-use starknet_rs::testing::starknet_state::StarknetState;
 
 use tracing::{debug, info};
 
@@ -19,11 +19,11 @@ use tracing::{debug, info};
 #[derive(Debug, Clone)]
 pub struct CairoApp {
     hasher: Arc<Mutex<Sha256>>,
-    starknet_state: StarknetState
+    starknet_state: StarknetState,
 }
 
 // because we don't get a `&mut self` in the ABCI API, we opt to have a mod-level variable
-// and because beginblock, endblock and deliver_tx all happen in the same thread, this is safe to do 
+// and because beginblock, endblock and deliver_tx all happen in the same thread, this is safe to do
 // an alternative would be Arc<Mutex<>>, but we want to avoid extra-overhead of locks for the benchmark's sake
 static mut TRANSACTIONS: usize = 0;
 static mut TIMER: Lazy<Instant> = Lazy::new(Instant::now);
@@ -257,10 +257,13 @@ impl CairoApp {
     pub fn new() -> Self {
         let new_state = Self {
             hasher: Arc::new(Mutex::new(Sha256::new())),
-            starknet_state: StarknetState::new(None)
+            starknet_state: StarknetState::new(None),
         };
 
-        info!("Starting with Starknet State: {:?}", new_state.starknet_state);
+        info!(
+            "Starting with Starknet State: {:?}",
+            new_state.starknet_state
+        );
         new_state
     }
 }

--- a/src/abci/application.rs
+++ b/src/abci/application.rs
@@ -105,12 +105,15 @@ impl Application for CairoApp {
     fn begin_block(&self, _request: abci::RequestBeginBlock) -> abci::ResponseBeginBlock {
         // because begin_block, [deliver_tx] and end_block/commit are on the same thread, this is safe to do (see declaration of statics)
         unsafe {
+            info!(
+                "{} ms passed between begin_block() calls. {} transactions, {} tps",
+                (*TIMER).elapsed().as_millis(),
+            TRANSACTIONS,
+            (TRANSACTIONS * 1000) as f32 / ((*TIMER).elapsed().as_millis() as f32)
+        );
             TRANSACTIONS = 0;
 
-            info!(
-                "{} ms passed between previous begin_block() and current begin_block()",
-                (*TIMER).elapsed().as_millis()
-            );
+
 
             *TIMER = Instant::now();
         }

--- a/src/bench/main.rs
+++ b/src/bench/main.rs
@@ -94,7 +94,7 @@ async fn run(transactions: Vec<Vec<u8>>, nodes: &Vec<SocketAddr>) {
     let time = Instant::now();
     let mut clients = vec![];
     for i in 0..nodes.len() {
-        let url = format!("http://{}",&nodes.get(i).unwrap());
+        let url = format!("http://{}", &nodes.get(i).unwrap());
         clients.push(HttpClient::new(url.as_str()).unwrap());
     }
 

--- a/src/bench/main.rs
+++ b/src/bench/main.rs
@@ -46,7 +46,7 @@ async fn main() {
     let transaction_type = TransactionType::FunctionExecution {
         program,
         function: "main".to_string(),
-        program_name: "fibonacci".to_string(),
+        program_name: "fibonacci.json".to_string(),
         enable_trace: false,
     };
 

--- a/src/bench/main.rs
+++ b/src/bench/main.rs
@@ -94,8 +94,7 @@ async fn run(transactions: Vec<Vec<u8>>, nodes: &Vec<SocketAddr>) {
     let time = Instant::now();
     let mut clients = vec![];
     for i in 0..nodes.len() {
-        let mut url = "http://".to_owned();
-        url.push_str(&nodes.get(i).unwrap().to_string());
+        let url = format!("http://{}",&nodes.get(i).unwrap());
         clients.push(HttpClient::new(url.as_str()).unwrap());
     }
 
@@ -104,7 +103,7 @@ async fn run(transactions: Vec<Vec<u8>>, nodes: &Vec<SocketAddr>) {
         let tx: tendermint::abci::Transaction = t.into();
 
         let c = clients.get(i % clients.len()); // get destination node
-        let response = c.unwrap().broadcast_tx_sync(tx).await;
+        let response = c.unwrap().broadcast_tx_async(tx).await;
 
         match &response {
             Ok(_) => {}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -24,6 +24,11 @@ pub struct Transaction {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum TransactionType {
+    Declare,
+    Deploy,
+    Invoke,
+
+    /// Legacy:
     FunctionExecution {
         program: String,
         function: String,

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -15,6 +15,7 @@ use starknet_rs::utils::Address;
 use starknet_rs::services::api::contract_class::{ContractClass, EntryPointType};
 use uuid::Uuid;
 
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Transaction {
     pub id: String,
@@ -28,7 +29,7 @@ pub enum TransactionType {
     Deploy,
     Invoke,
 
-    /// Legacy:
+    // TODO: Remove this when other transactions are implemented
     FunctionExecution {
         program: String,
         function: String,
@@ -125,6 +126,9 @@ impl TransactionType {
                 let hash = hasher.finalize().as_slice().to_owned();
                 Ok(hex::encode(hash))
             }
+            TransactionType::Declare => todo!(),
+            TransactionType::Deploy => todo!(),
+            TransactionType::Invoke => todo!(),
         }
     }
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -4,17 +4,16 @@ use anyhow::{ensure, Result};
 use felt::Felt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use starknet_rs::definitions::general_config::StarknetGeneralConfig;
-use starknet_rs::business_logic::state::cached_state::CachedState;
 use starknet_rs::business_logic::execution::execution_entry_point::ExecutionEntryPoint;
 use starknet_rs::business_logic::execution::objects::{CallType, TransactionExecutionContext};
-use starknet_rs::business_logic::fact_state::in_memory_state_reader::InMemoryStateReader;
 use starknet_rs::business_logic::fact_state::contract_state::ContractState;
+use starknet_rs::business_logic::fact_state::in_memory_state_reader::InMemoryStateReader;
 use starknet_rs::business_logic::fact_state::state::ExecutionResourcesManager;
-use starknet_rs::utils::Address;
+use starknet_rs::business_logic::state::cached_state::CachedState;
+use starknet_rs::definitions::general_config::StarknetGeneralConfig;
 use starknet_rs::services::api::contract_class::{ContractClass, EntryPointType};
+use starknet_rs::utils::Address;
 use uuid::Uuid;
-
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Transaction {
@@ -25,8 +24,13 @@ pub struct Transaction {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum TransactionType {
+    /// Create new contract class.
     Declare,
+
+    /// Create an instance of a contract which will have storage assigned. (Accounts are a contract themselves)
     Deploy,
+
+    /// Execute a function from a deployed contract.
     Invoke,
 
     // TODO: Remove this when other transactions are implemented
@@ -65,25 +69,23 @@ impl TransactionType {
                 program: _,
                 function,
                 program_name,
-                enable_trace: _
+                enable_trace: _,
             } => {
-
                 let general_config = StarknetGeneralConfig::default();
 
-                let tx_execution_context =
-                    TransactionExecutionContext::create_for_testing(
-                        Address(0.into()),
-                        10,
-                        0.into(),
-                        general_config.invoke_tx_max_n_steps(),
-                        1,
-                    );
+                let tx_execution_context = TransactionExecutionContext::create_for_testing(
+                    Address(0.into()),
+                    10,
+                    0.into(),
+                    general_config.invoke_tx_max_n_steps(),
+                    1,
+                );
 
                 let contract_address = Address(1111.into());
                 let class_hash = [1; 32];
                 let contract_class =
                     ContractClass::try_from(PathBuf::from("programs").join(program_name))
-                    .expect("Could not load contract from JSON");
+                        .expect("Could not load contract from JSON");
 
                 let contract_state = ContractState::new(
                     class_hash,
@@ -103,11 +105,13 @@ impl TransactionType {
                 let entry_point = ExecutionEntryPoint::new(
                     contract_address,
                     vec![],
-                    Felt::from_bytes_be(&starknet_rs::utils::calculate_sn_keccak(function.as_bytes())),
+                    Felt::from_bytes_be(&starknet_rs::utils::calculate_sn_keccak(
+                        function.as_bytes(),
+                    )),
                     Address(0.into()),
                     EntryPointType::External,
                     CallType::Delegate.into(),
-                    class_hash.into()
+                    class_hash.into(),
                 );
 
                 let mut resources_manager = ExecutionResourcesManager::default();


### PR DESCRIPTION
- Use temporary branch of `starknet_in_rust` that increases visibility of some structs (to introduce `StarknetState`)
- Add structure of transactions to implement
    - Declare: Create new contract
    - Deploy: Create an instance of a declared contract and assign storage
    - Invoke: Execute a function from a contract
