### PR TITLE
Add CI workflows to run check, fmt, and clippy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,61 @@
+name: Lambdaworks build checks
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  fmt:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            components: clippy
+      - run: make clippy

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ localnet_config:
 
 
 localnet_reset:
-	bin/tendermint unsafe_reset_all 
-		rm -rf localnet/node*/abci/abci.height; 
+	bin/tendermint unsafe_reset_all
+		rm -rf localnet/node*/abci/abci.height;
 .PHONY: localnet_reset
+
+.PHONY: clippy
+clippy:
+	cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Taken from [lambdaworks workflow](https://github.com/lambdaclass/lambdaworks/blob/main/.github/workflows/tests.yaml)