### PR TITLE
Updated tendermint-rs dependency to v0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cairo-felt"
@@ -231,7 +234,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "parse-hyperlinks",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -373,7 +376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -408,15 +411,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
+name = "curve25519-dalek-ng"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
+ "rand_core",
+ "subtle-ng",
  "zeroize",
 ]
 
@@ -473,13 +476,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
+name = "ed25519-consensus"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -1655,7 +1659,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1665,14 +1669,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -2306,6 +2304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,14 +2353,14 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.25.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b18e007aee6b81b449e92ea6e8c2dceec5e26d340a8f244450caf40938c5d9"
+checksum = "cda53c85447577769cdfc94c10a56f34afef2c00e4108badb57fce6b1a0c75eb"
 dependencies = [
- "async-trait",
  "bytes",
+ "digest 0.10.6",
  "ed25519",
- "ed25519-dalek",
+ "ed25519-consensus",
  "flex-error",
  "futures",
  "num-traits",
@@ -2367,7 +2371,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "signature",
  "subtle",
  "subtle-encoding",
@@ -2378,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-abci"
-version = "0.25.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a285e12a3c6416dac9bcc36570a80b54a4a9d123ac428ad31156d9b283a1b0f1"
+checksum = "7bfbe8f0131aa45769055496404359f4f5d3e2cf5d66c7457a5986806941de34"
 dependencies = [
  "bytes",
  "flex-error",
@@ -2391,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.25.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c9d7ec955d56a0f9cb9b8da32623bdc01461e79a18f6138850fdc97e7b6822"
+checksum = "dd4eb17618539c95b48501e71ad3c7f4bf047af388aa30dcf3e000782b05abfd"
 dependencies = [
  "flex-error",
  "serde",
@@ -2405,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.25.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d7f0f8cba8816446b330eeb25f73c3ba7cb9b261677bf78e6ea560b8e1880b"
+checksum = "c943f78c929cdf14553842f705f2c30324bc35b9179caaa5c9b80620f60652e6"
 dependencies = [
  "bytes",
  "flex-error",
@@ -2423,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.25.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5997ee5f4a65c84246ad1c3d156ab095109cc0d7dbeee3b8f0c6346d75e799d"
+checksum = "991779ca9b697471df9d436489774d144a418c0e5da843c58ff9288105d5ddaa"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2441,10 +2445,10 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "subtle",
  "subtle-encoding",
  "tendermint",
  "tendermint-config",
- "tendermint-proto",
  "thiserror",
  "time",
  "tokio",

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ abci:
 test:
 	RUST_BACKTRACE=full cargo test --release -- --nocapture --test-threads=4
 
-
 # Initialize the consensus configuration for a localnet of the given amount of validators
 localnet: VALIDATORS:=4
 localnet: ADDRESS:=127.0.0.1

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,15 @@ tendermint_config:
 	sed -i.bak 's/prometheus = false/prometheus = true/g' $(TENDERMINT_HOME)/config/config.toml
 
 # remove the blockchain data
-reset: bin/tendermint
+reset_tm: bin/tendermint
 	bin/tendermint unsafe_reset_all
 	rm -rf abci.height
+
+reset_cometbft:
+	bin/cometbft unsafe_reset_all
+	rm -rf abci.height
+
+reset: reset_tm
 
 # run the Cairo tendermint application
 abci:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: tendermint reset abci cli tendermint_config tendermint_install rollkit_celestia bitcoin celestia
+.PHONY: reset abci cli consensus_config consensus_install rollkit_celestia bitcoin celestia
 
 OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 
@@ -8,8 +8,20 @@ else
 ARCH=amd64
 endif
 
-TMINT_VERSION=0.34.22
-TENDERMINT_HOME=~/.tendermint/
+# By default consensus protocol is tendermint. Can be overriden with cometbft
+CONSENSUS=tendermint
+
+ifeq ($(CONSENSUS), tendermint)
+CONSENSUS_VERSION=0.34.22
+CONSENSUS_HOME=~/.tendermint/
+else
+CONSENSUS=cometbft
+CONSENSUS_VERSION=0.34.27
+CONSENSUS_HOME=~/.cometbft/
+endif
+
+test_make:
+	echo "CONSENSUS = $(CONSENSUS) version=$(CONSENSUS_VERSION) home=$(CONSENSUS_HOME)"
 
 # Build the client program and put it in bin/aleo
 cli:
@@ -18,38 +30,36 @@ cli:
 
 # Installs tendermint for current OS and puts it in bin/
 bin/tendermint:
-	make tendermint_install
-	mv tendermint-install/tendermint bin/ && rm -rf tendermint-install
+	make consensus_install CONSENSUS=tendermint
 
-# Internal phony target to install tendermint for an arbitrary OS
-tendermint_install:
-	mkdir -p tendermint-install bin && cd tendermint-install &&\
-	wget https://github.com/tendermint/tendermint/releases/download/v$(TMINT_VERSION)/tendermint_$(TMINT_VERSION)_$(OS)_$(ARCH).tar.gz &&\
-	tar -xzvf tendermint_$(TMINT_VERSION)_$(OS)_$(ARCH).tar.gz
+# Installs cometbft for current OS and puts it in bin/
+bin/cometbft:
+	make consensus_install CONSENSUS=cometbft
 
-# Run a tendermint node, installing it if necessary
-node: tendermint_config
-	bin/tendermint node
+# Internal phony target to install tendermint/cometbft for an arbitrary OS
+consensus_install:
+	mkdir -p $(CONSENSUS)-install bin && cd $(CONSENSUS)-install &&\
+	wget https://github.com/$(CONSENSUS)/$(CONSENSUS)/releases/download/v$(CONSENSUS_VERSION)/$(CONSENSUS)_$(CONSENSUS_VERSION)_$(OS)_$(ARCH).tar.gz &&\
+	tar -xzvf $(CONSENSUS)_$(CONSENSUS_VERSION)_$(OS)_$(ARCH).tar.gz
+	mv $(CONSENSUS)-install/$(CONSENSUS) bin/ && rm -rf $(CONSENSUS)-install
 
-# Override a tendermint node's default configuration. NOTE: we should do something more declarative if we need to update more settings.
-tendermint_config:
-	sed -i.bak 's/max_body_bytes = 1000000/max_body_bytes = 12000000/g' $(TENDERMINT_HOME)/config/config.toml
-	sed -i.bak 's/max_tx_bytes = 1048576/max_tx_bytes = 10485770/g' $(TENDERMINT_HOME)/config/config.toml
-	sed -i.bak 's#laddr = "tcp://127.0.0.1:26657"#laddr = "tcp://0.0.0.0:26657"#g' $(TENDERMINT_HOME)/config/config.toml
-	sed -i.bak 's/prometheus = false/prometheus = true/g' $(TENDERMINT_HOME)/config/config.toml
+# Run a consensus node, installing it if necessary
+node: bin/$(CONSENSUS) consensus_config
+	bin/$(CONSENSUS) node
+
+# Override a tendermint/cometbft node's default configuration. NOTE: we should do something more declarative if we need to update more settings.
+consensus_config:
+	sed -i.bak 's/max_body_bytes = 1000000/max_body_bytes = 12000000/g' $(CONSENSUS_HOME)/config/config.toml
+	sed -i.bak 's/max_tx_bytes = 1048576/max_tx_bytes = 10485770/g' $(CONSENSUS_HOME)/config/config.toml
+	sed -i.bak 's#laddr = "tcp://127.0.0.1:26657"#laddr = "tcp://0.0.0.0:26657"#g' $(CONSENSUS_HOME)/config/config.toml
+	sed -i.bak 's/prometheus = false/prometheus = true/g' $(CONSENSUS_HOME)/config/config.toml
 
 # remove the blockchain data
-reset_tm: bin/tendermint
-	bin/tendermint unsafe_reset_all
+reset: bin/$(CONSENSUS)
+	bin/$(CONSENSUS) unsafe_reset_all
 	rm -rf abci.height
 
-reset_cometbft:
-	bin/cometbft unsafe_reset_all
-	rm -rf abci.height
-
-reset: reset_tm
-
-# run the Cairo tendermint application
+# run the Cairo abci application
 abci:
 	cargo run --release  --bin abci
 
@@ -58,45 +68,45 @@ test:
 	RUST_BACKTRACE=full cargo test --release -- --nocapture --test-threads=4
 
 
-# Initialize the tendermint configuration for a localnet of the given amount of validators
+# Initialize the consensus configuration for a localnet of the given amount of validators
 localnet: VALIDATORS:=4
 localnet: ADDRESS:=127.0.0.1
 localnet: HOMEDIR:=localnet
-localnet: bin/tendermint cli
+localnet: bin/consensus cli
 	rm -rf $(HOMEDIR)/
-	bin/tendermint testnet --v $(VALIDATORS) --o ./$(HOMEDIR) --starting-ip-address $(ADDRESS)
+	bin/$(CONSENSUS) testnet --v $(VALIDATORS) --o ./$(HOMEDIR) --starting-ip-address $(ADDRESS)
 	for n in $$(seq 0 $$(($(VALIDATORS)-1))) ; do \
-        make localnet_config TENDERMINT_HOME=$(HOMEDIR)/node$$n NODE=$$n VALIDATORS=$(VALIDATORS); \
+        make localnet_config CONSENSUS_HOME=$(HOMEDIR)/node$$n NODE=$$n VALIDATORS=$(VALIDATORS); \
 		mkdir $(HOMEDIR)/node$$n/abci ; \
 	done
 .PHONY: localnet
 # cargo run --bin genesis --release -- $(HOMEDIR)/*
 
-# run both the abci application and the tendermint node
+# run both the abci application and the consensus node
 # assumes config for each node has been done previously
 localnet_start: NODE:=0
 localnet_start: HOMEDIR:=localnet
 localnet_start:
-	bin/tendermint node --home ./$(HOMEDIR)/node$(NODE) &
+	bin/$(CONSENSUS) node --home ./$(HOMEDIR)/node$(NODE) &
 	cd ./$(HOMEDIR)/node$(NODE)/abci; cargo run --release --bin abci -- --port 26$(NODE)58
 .PHONY: localnet_start
 
 
 localnet_config:
-	sed -i.bak 's/max_body_bytes = 1000000/max_body_bytes = 12000000/g' $(TENDERMINT_HOME)/config/config.toml
-	sed -i.bak 's/max_tx_bytes = 1048576/max_tx_bytes = 10485770/g' $(TENDERMINT_HOME)/config/config.toml
-	sed -i.bak 's/prometheus = false/prometheus = true/g' $(TENDERMINT_HOME)/config/config.toml
+	sed -i.bak 's/max_body_bytes = 1000000/max_body_bytes = 12000000/g' $(CONSENSUS_HOME)/config/config.toml
+	sed -i.bak 's/max_tx_bytes = 1048576/max_tx_bytes = 10485770/g' $(CONSENSUS_HOME)/config/config.toml
+	sed -i.bak 's/prometheus = false/prometheus = true/g' $(CONSENSUS_HOME)/config/config.toml
 	for n in $$(seq 0 $$(($(VALIDATORS)-1))) ; do \
-	    eval "sed -i.bak 's/127.0.0.$$(($${n}+1)):26656/127.0.0.1:26$${n}56/g' $(TENDERMINT_HOME)/config/config.toml" ;\
+	    eval "sed -i.bak 's/127.0.0.$$(($${n}+1)):26656/127.0.0.1:26$${n}56/g' $(CONSENSUS_HOME)/config/config.toml" ;\
 	done
-	sed -i.bak 's#laddr = "tcp://0.0.0.0:26656"#laddr = "tcp://0.0.0.0:26$(NODE)56"#g' $(TENDERMINT_HOME)/config/config.toml
-	sed -i.bak 's#laddr = "tcp://127.0.0.1:26657"#laddr = "tcp://0.0.0.0:26$(NODE)57"#g' $(TENDERMINT_HOME)/config/config.toml
-	sed -i.bak 's#proxy_app = "tcp://127.0.0.1:26658"#proxy_app = "tcp://127.0.0.1:26$(NODE)58"#g' $(TENDERMINT_HOME)/config/config.toml
+	sed -i.bak 's#laddr = "tcp://0.0.0.0:26656"#laddr = "tcp://0.0.0.0:26$(NODE)56"#g' $(CONSENSUS_HOME)/config/config.toml
+	sed -i.bak 's#laddr = "tcp://127.0.0.1:26657"#laddr = "tcp://0.0.0.0:26$(NODE)57"#g' $(CONSENSUS_HOME)/config/config.toml
+	sed -i.bak 's#proxy_app = "tcp://127.0.0.1:26658"#proxy_app = "tcp://127.0.0.1:26$(NODE)58"#g' $(CONSENSUS_HOME)/config/config.toml
 .PHONY: localnet_config
 
 
 localnet_reset:
-	bin/tendermint unsafe_reset_all
+	bin/$(CONSENSUS) unsafe_reset_all
 		rm -rf localnet/node*/abci/abci.height;
 .PHONY: localnet_reset
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make celestia
 Install `Tendermint` and initialize it. This will initialize the required files that rollkit will use when running:
 
 ```sh
-make tendermint_install
+make consensus_install
 bin/tendermint init
 ```
 
@@ -65,7 +65,7 @@ make abci
 If Tendermint is not installed, install and initialize it. This will initialize the required files that rollkit will use when running:
 
 ```sh
-make tendermint_install
+make consensus_install
 bin/tendermint init
 ```
 
@@ -111,6 +111,23 @@ To send executions to the sequencer you need to have a compiled Cairo program (*
 ```bash
 cargo run --release programs/fibonacci.json main
 ```
+
+### Running [CometBFT](https://github.com/cometbft/cometbft) instead of Tendermint
+
+Current code can be run with both Tendermint and CometBFT (up to version 0.34.27). In order to use CometBFT the make command should include the `CONSENSUS` variable:
+
+```bash
+make node CONSENSUS=cometbft
+```
+
+This will run CometBFT instead of Tendermint (and also will install and configure it if not present).
+
+Also
+
+```bash
+make consensus_intall CONSENSUS=cometbft
+```
+will run the CometBFT installation script
 
 ### Benchmark
 
@@ -192,6 +209,7 @@ Check [tm-load-test](https://github.com/informalsystems/tm-load-test) and [Tende
 * [tendermint-rs](https://github.com/informalsystems/tendermint-rs)
 * [ABCI overview](https://docs.tendermint.com/v0.34/introduction/what-is-tendermint.html#abci-overview)
 * [ABCI v0.34 reference](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/abci.md)
+* [CometBFT](https://github.com/cometbft/cometbft)
 * [About why app hash is needed](https://github.com/tendermint/tendermint/issues/1179). Also [this](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/abci/apps.md#query-proofs).
 * [About Tendermint 0.34's future](https://github.com/tendermint/tendermint/issues/9972)
 ### Starknet

--- a/sequencer/Cargo.toml
+++ b/sequencer/Cargo.toml
@@ -34,10 +34,10 @@ hex = "0.4.3"
 sha2 = "0.10.6"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["raw_value"] }
-tendermint = "0.25.0"
-tendermint-abci = "0.25.0"
-tendermint-proto = { version = "0.25.0", defaultt-features = false }
-tendermint-rpc = { version = "0.25.0", features = ["http-client"] }
+tendermint = "0.29.0"
+tendermint-abci = "0.29.0"
+tendermint-proto = { version = "0.29.0", default-features = false }
+tendermint-rpc = { version = "0.29.0", features = ["http-client"] }
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["env-filter", "fmt", "std"]}
 tokio = { version = "1.15.0", features = ["full"] }

--- a/sequencer/src/abci/application.rs
+++ b/sequencer/src/abci/application.rs
@@ -51,7 +51,7 @@ impl Application for StarknetApp {
             last_block_height: HeightFile::read_or_create(),
 
             // using a fixed hash, see the commit() hook
-            last_block_app_hash: vec![],
+            last_block_app_hash: vec![].into(),
         }
     }
 
@@ -148,8 +148,8 @@ impl Application for StarknetApp {
                 let index_event = abci::Event {
                     r#type: "app".to_string(),
                     attributes: vec![abci::EventAttribute {
-                        key: "tx_id".to_string().into_bytes(),
-                        value: tx.transaction_hash.to_string().into_bytes(),
+                        key: "tx_id".into(),
+                        value: tx.transaction_hash.clone().into(),
                         index: true,
                     }],
                 };
@@ -163,8 +163,8 @@ impl Application for StarknetApp {
                         let function_event = abci::Event {
                             r#type: "function".to_string(),
                             attributes: vec![abci::EventAttribute {
-                                key: "function".to_string().into_bytes(),
-                                value: function.into_bytes(),
+                                key: "function".into(),
+                                value: function.into(),
                                 index: true,
                             }],
                         };
@@ -177,7 +177,7 @@ impl Application for StarknetApp {
 
                 abci::ResponseDeliverTx {
                     events,
-                    data: tx.transaction_hash.into_bytes(),
+                    data: tx.transaction_hash.into(),
                     ..Default::default()
                 }
             }
@@ -237,12 +237,12 @@ impl Application for StarknetApp {
 
         match app_hash {
             Ok(hash) => abci::ResponseCommit {
-                data: hash,
+                data: hash.into(),
                 retain_height: 0,
             },
             // error should be handled here
             _ => abci::ResponseCommit {
-                data: vec![],
+                data: vec![].into(),
                 retain_height: 0,
             },
         }
@@ -278,8 +278,8 @@ impl HeightFile {
             // if contents are not readable, crash intentionally
             bincode::deserialize(&bytes).expect("Contents of height file are not readable")
         } else {
-            std::fs::write(Self::PATH, bincode::serialize(&1i64).unwrap()).unwrap();
-            1i64
+            std::fs::write(Self::PATH, bincode::serialize(&0i64).unwrap()).unwrap();
+            0i64
         }
     }
 

--- a/sequencer/src/bench/main.rs
+++ b/sequencer/src/bench/main.rs
@@ -102,10 +102,9 @@ async fn run(transactions: Vec<Vec<u8>>, nodes: &Vec<SocketAddr>) {
     let n_transactions = transactions.len();
     // for each transaction in this thread, send transactions in a round robin fashion to each node
     for (i, t) in transactions.into_iter().enumerate() {
-        let tx: tendermint::abci::Transaction = t.into();
 
         let c = clients.get(i % clients.len()); // get destination node
-        let response = c.unwrap().broadcast_tx_async(tx).await;
+        let response = c.unwrap().broadcast_tx_async(t).await;
 
         match &response {
             Ok(_) => {}

--- a/sequencer/src/bench/main.rs
+++ b/sequencer/src/bench/main.rs
@@ -102,7 +102,6 @@ async fn run(transactions: Vec<Vec<u8>>, nodes: &Vec<SocketAddr>) {
     let n_transactions = transactions.len();
     // for each transaction in this thread, send transactions in a round robin fashion to each node
     for (i, t) in transactions.into_iter().enumerate() {
-
         let c = clients.get(i % clients.len()); // get destination node
         let response = c.unwrap().broadcast_tx_async(t).await;
 

--- a/sequencer/src/cli/main.rs
+++ b/sequencer/src/cli/main.rs
@@ -95,8 +95,7 @@ async fn run(
 pub async fn broadcast(transaction: Vec<u8>, url: &str) -> Result<()> {
     let client = HttpClient::new(url).unwrap();
 
-    let tx: tendermint::abci::Transaction = transaction.into();
-    let response = client.broadcast_tx_sync(tx).await?;
+    let response = client.broadcast_tx_sync(transaction).await?;
 
     debug!("Response from CheckTx: {:?}", response);
     match response.code {


### PR DESCRIPTION
Updated tendermint-rs to a version that is compatible with both Tendermint v.0.34.22 and CometBFT v0.34.27

This code runs on both projects seamlessly 