### PR TITLE
Send transaction to prover

### DIFF
--- a/sequencer/programs/sharp_fibonacci.cairo
+++ b/sequencer/programs/sharp_fibonacci.cairo
@@ -3,7 +3,8 @@
 func main(output_ptr: felt*) -> (output_ptr: felt*) {
     // Call fib(1, 1, 10).
     let result: felt = fib(1, 1, 500);
-    return (output_ptr=output_ptr);
+    assert [output_ptr] = result;
+    return (output_ptr=output_ptr+1);
 }
 
 func fib(first_element, second_element, n) -> (res: felt) {

--- a/sequencer/programs/sharp_fibonacci.cairo
+++ b/sequencer/programs/sharp_fibonacci.cairo
@@ -1,0 +1,17 @@
+%builtins output
+
+func main(output_ptr: felt*) -> (output_ptr: felt*) {
+    // Call fib(1, 1, 10).
+    let result: felt = fib(1, 1, 500);
+    return (output_ptr=output_ptr);
+}
+
+func fib(first_element, second_element, n) -> (res: felt) {
+    jmp fib_body if n != 0;
+    tempvar result = second_element;
+    return (second_element,);
+
+    fib_body:
+    tempvar y = first_element + second_element;
+    return fib(second_element, y, n - 1);
+}

--- a/sequencer/src/cli/main.rs
+++ b/sequencer/src/cli/main.rs
@@ -33,6 +33,9 @@ pub struct Cli {
     /// tendermint node url
     #[clap(short, long, env = "SEQUENCER_URL", default_value = LOCAL_SEQUENCER_URL)]
     pub url: String,
+
+    #[clap(short, long, global = false, default_value_t = false)]
+    pub send_to_prover: bool,
 }
 
 #[tokio::main()]
@@ -49,11 +52,18 @@ async fn main() {
             .init();
     }
 
-    let (exit_code, output) =
-        match run(&cli.path, &cli.function_name, &cli.url, cli.no_broadcast).await {
-            Ok(output) => (0, output),
-            Err(err) => (1, format!("error: {err}")),
-        };
+    let (exit_code, output) = match run(
+        &cli.path,
+        &cli.function_name,
+        &cli.url,
+        cli.no_broadcast,
+        cli.send_to_prover,
+    )
+    .await
+    {
+        Ok(output) => (0, output),
+        Err(err) => (1, format!("error: {err}")),
+    };
 
     println!("{output:#}");
     std::process::exit(exit_code);
@@ -64,17 +74,29 @@ async fn run(
     function_name: &str,
     sequencer_url: &str,
     no_broadcast: bool,
+    send_to_prover: bool,
 ) -> Result<String> {
     let _program = fs::read_to_string(path)?;
+    let program = fs::read_to_string(path)?;
+    let function = function_name.to_owned();
+    let program_name = path
+        .file_name()
+        .expect("Error getting file name")
+        .to_string_lossy()
+        .to_string();
 
-    let transaction_type = TransactionType::FunctionExecution {
-        function: function_name.to_owned(),
-        program_name: path
-            .file_name()
-            .expect("Error getting file name")
-            .to_string_lossy()
-            .to_string(),
+    let transaction_type = match send_to_prover {
+        false => TransactionType::FunctionExecution {
+            function,
+            program_name,
+        },
+        true => TransactionType::FunctionExecutionProver {
+            program,
+            function,
+            program_name,
+        },
     };
+
     let transaction = Transaction::with_type(transaction_type)?;
 
     let transaction_serialized = bincode::serialize(&transaction).unwrap();

--- a/sequencer/src/lib/mod.rs
+++ b/sequencer/src/lib/mod.rs
@@ -38,6 +38,12 @@ pub enum TransactionType {
         function: String,
         program_name: String,
     },
+
+    FunctionExecutionProver {
+        program: String,
+        function: String,
+        program_name: String,
+    },
 }
 
 impl Transaction {
@@ -121,6 +127,16 @@ impl TransactionType {
                     )
                     .expect("Could not execute contract");
 
+                let mut hasher = Sha256::new();
+                hasher.update(function);
+                let hash = hasher.finalize().as_slice().to_owned();
+                Ok(hex::encode(hash))
+            }
+            TransactionType::FunctionExecutionProver {
+                program: _,
+                function,
+                program_name: _,
+            } => {
                 let mut hasher = Sha256::new();
                 hasher.update(function);
                 let hash = hasher.finalize().as_slice().to_owned();


### PR DESCRIPTION
This PR adds a cli option `--send-to-prover` to enable sending proofs to SHARP through the `cairo-sharp` cli (you will need this installed)

One caveat of using `cairo-sharp` to send to SHARP is that it can only work with cairo programs, not contracts, so we need to give it a cairo program and it will compile, run, and send to the prover. All this is painfully slow, on my regular laptop takes at least 10 seconds for our simple fibonacci example.

Additionally we have 2 problems
1. The ABCI does not provide all transactions during `end_block` or `commit` so no way to pool them for sending
2. Invoking `cairo-sharp` will block the ABCI  thread for it and thus block consensus work

To address this problems the ABCI thread on initialization spawns another thread that will do the following
1. Receive transactions from `deliver_tx`
2. Receive signal from `commit` to process transactions (send to prover)