### PR TITLE
Add support for transaction type: declare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,261 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
+name = "actix-codec"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util 0.7.7",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "ahash 0.8.3",
+ "base64 0.21.0",
+ "bitflags 1.3.2",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "futures-core",
+ "h2",
+ "http",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-util 0.7.7",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+dependencies = [
+ "bytestring",
+ "http",
+ "regex",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8613a75dd50cc45f473cee3c34d59ed677c0f7b44480ce3b8247d7dc519327"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "num_cpus",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+dependencies = [
+ "futures-core",
+ "paste",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-tls"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "http",
+ "log",
+ "pin-project-lite",
+ "tokio-util 0.7.7",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "ahash 0.7.6",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "ark-ff"
@@ -33,7 +284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -45,7 +296,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -76,13 +327,13 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
-version = "0.1.66"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -101,6 +352,40 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "awc"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ef547a81796eb2dfe9b345aba34c2e08391a0502493711395b36dd64052b69"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-rt",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "ahash 0.7.6",
+ "base64 0.21.0",
+ "bytes",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "itoa",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
 
 [[package]]
 name = "base64"
@@ -141,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+
+[[package]]
 name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -176,6 +467,27 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bumpalo"
@@ -202,6 +514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -249,6 +570,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -263,7 +587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
@@ -275,13 +599,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
 dependencies = [
- "bitflags",
- "clap_derive 4.1.8",
- "clap_lex 0.3.2",
+ "bitflags 2.0.2",
+ "clap_derive 4.1.9",
+ "clap_lex 0.3.3",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -298,20 +622,20 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.8"
+version = "4.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -325,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
@@ -337,6 +661,17 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -361,6 +696,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -431,7 +775,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -444,7 +788,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -462,7 +806,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
 ]
 
@@ -598,6 +942,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flex-error"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,9 +999,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -660,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -670,15 +1024,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -687,32 +1041,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-timer"
@@ -722,9 +1076,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -770,7 +1124,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -805,7 +1159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -905,9 +1259,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1033,7 +1387,7 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1064,10 +1418,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -1080,9 +1435,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1104,6 +1459,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1139,6 +1503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,9 +1516,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -1165,6 +1535,24 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "local-channel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
@@ -1217,15 +1605,24 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1297,7 +1694,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1343,11 +1740,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1364,7 +1761,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1375,9 +1772,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
 dependencies = [
  "autocfg",
  "cc",
@@ -1388,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "overload"
@@ -1421,7 +1818,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1521,7 +1918,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1580,7 +1977,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1597,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -1624,7 +2021,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1638,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1687,7 +2084,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1696,6 +2093,8 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1716,9 +2115,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -1808,16 +2207,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1914,7 +2313,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1942,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "semver-parser"
@@ -1957,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a382c72b4ba118526e187430bb4963cd6d55051ebf13d9b25574d379cc98d20"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
@@ -1975,13 +2374,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef476a5790f0f6decbc66726b6e5d63680ed518283e64c7df415989d880954f"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -1997,13 +2396,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -2187,7 +2586,7 @@ checksum = "6569d70430f0f6edc41f6820d00acf63356e6308046ca01e57eeac22ad258c47"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2218,10 +2617,13 @@ dependencies = [
 [[package]]
 name = "starknet-rs"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/starknet_in_rust?branch=publish-structs#bad3c784285495705ceac376ed6820232ab84cb1"
+source = "git+https://github.com/lambdaclass/starknet_in_rust?branch=publish-structs#053cda1ead2fb9b55c578779d83a816027dd5a98"
 dependencies = [
+ "actix-web",
+ "awc",
  "cairo-felt",
  "cairo-vm",
+ "clap 4.1.11",
  "getset",
  "lazy_static",
  "num-bigint",
@@ -2242,7 +2644,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "cairo-felt",
- "clap 4.1.8",
+ "clap 4.1.11",
  "futures",
  "hex",
  "once_cell",
@@ -2321,6 +2723,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,7 +2741,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -2442,7 +2855,7 @@ dependencies = [
  "hyper-rustls",
  "peg",
  "pin-project",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -2476,22 +2889,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -2510,6 +2923,7 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
  "time-macros",
@@ -2582,7 +2996,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2663,9 +3077,9 @@ checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2685,6 +3099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2698,7 +3113,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2772,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -2849,12 +3264,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -2895,7 +3309,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -2929,7 +3343,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3074,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -3089,51 +3503,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
 ]
@@ -3170,6 +3584,36 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.4+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7afb4b54b8910cf5447638cb54bf4e8a65cbedd783af98b98c62ffe91f185543"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.7+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]

--- a/cairo_programs/contracts.json
+++ b/cairo_programs/contracts.json
@@ -1,0 +1,12556 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "compiler_version": "0.10.3",
+    "data": [
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffb7ffc",
+        "0x400380017ffb7ffd",
+        "0x482680017ffb8000",
+        "0x3",
+        "0x480280027ffb8000",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff8",
+        "0x400780017fff8000",
+        "0x0",
+        "0x400780017fff8001",
+        "0x0",
+        "0x48127ffe7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x2",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x480280007ffb8000",
+        "0x1104800180018000",
+        "0x2b",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe8",
+        "0x40137ffd7fff8000",
+        "0x480280017ffb8000",
+        "0x40297ffd7fff8001",
+        "0x48127ffb7fff8000",
+        "0x48127ffc7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x2",
+        "0x480a7ffb7fff8000",
+        "0x480280007ffc8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdc",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd9",
+        "0x40137ffd7fff8000",
+        "0x480280017ffc8000",
+        "0x402580017fff8001",
+        "0x1",
+        "0x48127ffb7fff8000",
+        "0x48127ffc7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x27",
+        "0x48127ffe7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x48127ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe9",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffc7fff8000",
+        "0x480280007ffd8000",
+        "0x480280017ffd8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc3",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffc",
+        "0x5",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x1",
+        "0x482680017ffc8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x40337fff7ffb8000",
+        "0x480a7ffb7fff8000",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x48317ffd80008000",
+        "0x400080007ffd7ffe",
+        "0x480080007ffc8000",
+        "0x400080017ffc7fff",
+        "0x482480017ffb8000",
+        "0x1",
+        "0x482480017ffb8000",
+        "0x3",
+        "0x480080027ffa8000",
+        "0x20680017fff7ffb",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff8",
+        "0x208b7fff7fff7ffe",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffad",
+        "0x480a7ffb7fff8000",
+        "0x48127ffe7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb1",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffda",
+        "0x208b7fff7fff7ffe",
+        "0x480280007ffb8000",
+        "0x480280017ffb8000",
+        "0x484480017fff8000",
+        "0x2aaaaaaaaaaaab05555555555555556",
+        "0x48307fff7ffd8000",
+        "0x480280027ffb8000",
+        "0x480280037ffb8000",
+        "0x484480017fff8000",
+        "0x4000000000000088000000000000001",
+        "0x48307fff7ffd8000",
+        "0xa0680017fff8000",
+        "0xe",
+        "0x480680017fff8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x48287ffc80007fff",
+        "0x40307ffc7ff87fff",
+        "0x48297ffd80007ffc",
+        "0x482680017ffd8000",
+        "0x1",
+        "0x48507fff7ffe8000",
+        "0x40507ff97ff57fff",
+        "0x482680017ffb8000",
+        "0x4",
+        "0x208b7fff7fff7ffe",
+        "0xa0680017fff8000",
+        "0xc",
+        "0x480680017fff8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x48287ffd80007fff",
+        "0x48327fff7ffc8000",
+        "0x40307ffa7ff67fff",
+        "0x48527ffe7ffc8000",
+        "0x40507ff97ff57fff",
+        "0x482680017ffb8000",
+        "0x4",
+        "0x208b7fff7fff7ffe",
+        "0x40317ffd7ff97ffd",
+        "0x48297ffc80007ffd",
+        "0x48527fff7ffc8000",
+        "0x40507ffb7ff77fff",
+        "0x40780017fff7fff",
+        "0x2",
+        "0x482680017ffb8000",
+        "0x4",
+        "0x208b7fff7fff7ffe",
+        "0x48297ffd80007ffc",
+        "0x20680017fff7fff",
+        "0x4",
+        "0x402780017ffc7ffc",
+        "0x1",
+        "0x480a7ffb7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffcc",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffc",
+        "0x4",
+        "0x480a7ffb7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffb7fff8000",
+        "0x482680017ffc8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x482680017ffd8000",
+        "0x2",
+        "0x480280007ffd8000",
+        "0x1104800180018000",
+        "0x3",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffb",
+        "0x4",
+        "0x480a7ffa7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x480280007ffc8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe2",
+        "0x482680017ffb8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x482680017ffc8000",
+        "0x2",
+        "0x480280007ffc8000",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff3",
+        "0x208b7fff7fff7ffe",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff4c",
+        "0x480a7ffc7fff8000",
+        "0x48127ffe7fff8000",
+        "0x480280007ffd8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff61",
+        "0x480280017ffd8000",
+        "0x48127ffd7fff8000",
+        "0x48127ffd7fff8000",
+        "0x480280027ffd8000",
+        "0x484480017ffc8000",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff69",
+        "0x480280037ffd8000",
+        "0x48127ffd7fff8000",
+        "0x48127ffd7fff8000",
+        "0x480280047ffd8000",
+        "0x484480017ffc8000",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff61",
+        "0x480280057ffd8000",
+        "0x48127ffd7fff8000",
+        "0x48127ffd7fff8000",
+        "0x480280067ffd8000",
+        "0x484480017ffc8000",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff59",
+        "0x480280087ffd8000",
+        "0x480280077ffd8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff55",
+        "0x480280097ffd8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff42",
+        "0x4802800b7ffd8000",
+        "0x4802800a7ffd8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff4e",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff57",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x2",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffd7fff8000",
+        "0x480a80007fff8000",
+        "0x480a80017fff8000",
+        "0x1104800180018000",
+        "0x5",
+        "0x480a80007fff8000",
+        "0x480a80017fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffc",
+        "0x5",
+        "0x480a7ffa7fff8000",
+        "0x480a7ffb7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x40780017fff7fff",
+        "0x1",
+        "0x480280017ffd8000",
+        "0x480680017fff8000",
+        "0x0",
+        "0x400080007ffe7fff",
+        "0x480280017ffd8000",
+        "0x480280017ffd8000",
+        "0x480a7ffb7fff8000",
+        "0x480080017ffd8000",
+        "0x480080027ffd8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff9b",
+        "0x480280017ffd8000",
+        "0x480280017ffd8000",
+        "0x48127ffd7fff8000",
+        "0x480080037ffd8000",
+        "0x480080047ffd8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff94",
+        "0x40137fff7fff8000",
+        "0x480a7ffa7fff8000",
+        "0x480280017ffd8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffad",
+        "0x400280007ffd7fff",
+        "0x48127ffe7fff8000",
+        "0x480a80007fff8000",
+        "0x482680017ffc8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x482680017ffd8000",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdc",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "starkware.cairo.lang.compiler.lib.registers",
+                    "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 73,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 7
+                }
+            },
+            "1": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 2,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 14,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 14
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 2,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 15
+                }
+            },
+            "3": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 34,
+                            "end_line": 13,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 28,
+                                    "end_line": 18,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 18
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 13
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 20,
+                    "start_line": 17
+                }
+            },
+            "5": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 18,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 18
+                        },
+                        "While expanding the reference 'result' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 16
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash",
+                    "starkware.cairo.common.hash.hash2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash.hash2.hash_ptr": 4,
+                        "starkware.cairo.common.hash.hash2.result": 3,
+                        "starkware.cairo.common.hash.hash2.x": 0,
+                        "starkware.cairo.common.hash.hash2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 18
+                }
+            },
+            "7": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_init"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 18,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 18
+                }
+            },
+            "9": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_init"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 19,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 19
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_init"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_init.__fp__": 5,
+                        "starkware.cairo.common.hash_state.hash_init.hash_state": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 21,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 21
+                }
+            },
+            "13": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_init"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_init.__fp__": 5,
+                        "starkware.cairo.common.hash_state.hash_init.hash_state": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 22,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 22
+                }
+            },
+            "15": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_init"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_init.__fp__": 5,
+                        "starkware.cairo.common.hash_state.hash_init.hash_state": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 16,
+                    "end_line": 19,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 21,
+                            "end_line": 20,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 39,
+                                    "end_line": 23,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 29,
+                                    "start_line": 23
+                                },
+                                "While expanding the reference 'hash_state' in:"
+                            ],
+                            "start_col": 11,
+                            "start_line": 20
+                        },
+                        "While expanding the reference '__fp__' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 19
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_init"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_init.__fp__": 5,
+                        "starkware.cairo.common.hash_state.hash_init.hash_state": 6
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 23
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 10,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 32,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 32
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 10,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 29,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 46,
+                            "end_line": 78,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 35,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 18,
+                                    "start_line": 33
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 24,
+                            "start_line": 78
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 18,
+                    "start_line": 29
+                }
+            },
+            "20": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 10,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 48,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 34,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 18,
+                            "start_line": 34
+                        },
+                        "While expanding the reference 'data_ptr' in:"
+                    ],
+                    "start_col": 33,
+                    "start_line": 30
+                }
+            },
+            "21": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 10,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 30,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 51,
+                            "end_line": 34,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 40,
+                            "start_line": 34
+                        },
+                        "While expanding the reference 'data_length' in:"
+                    ],
+                    "start_col": 50,
+                    "start_line": 30
+                }
+            },
+            "22": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 10,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 85,
+                    "end_line": 34,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 58,
+                    "start_line": 34
+                }
+            },
+            "23": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 10,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 35,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 33
+                }
+            },
+            "25": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash": 12,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 11,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 36
+                }
+            },
+            "27": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.__fp__": 13,
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash": 12,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 11,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7,
+                        "starkware.cairo.common.hash_state.hash_update.new_hash_state": 14
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 38,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 38
+                }
+            },
+            "28": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.__fp__": 13,
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash": 12,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 11,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7,
+                        "starkware.cairo.common.hash_state.hash_update.new_hash_state": 14
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 59,
+                    "end_line": 39,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 37,
+                    "start_line": 39
+                }
+            },
+            "29": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.__fp__": 13,
+                        "starkware.cairo.common.hash_state.hash_update.__temp0": 15,
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash": 12,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 11,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7,
+                        "starkware.cairo.common.hash_state.hash_update.new_hash_state": 14
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 74,
+                    "end_line": 39,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 39
+                }
+            },
+            "30": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.__fp__": 13,
+                        "starkware.cairo.common.hash_state.hash_update.__temp0": 15,
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash": 12,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 11,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7,
+                        "starkware.cairo.common.hash_state.hash_update.new_hash_state": 14
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 78,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 6,
+                            "end_line": 35,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 40,
+                                    "end_line": 29,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 49,
+                                            "end_line": 40,
+                                            "input_file": {
+                                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 40
+                                        },
+                                        "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                                    ],
+                                    "start_col": 18,
+                                    "start_line": 29
+                                },
+                                "While expanding the reference 'hash_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 33
+                        },
+                        "While trying to update the implicit return value 'hash_ptr' in:"
+                    ],
+                    "start_col": 24,
+                    "start_line": 78
+                }
+            },
+            "31": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.__fp__": 13,
+                        "starkware.cairo.common.hash_state.hash_update.__temp0": 15,
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash": 12,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 11,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7,
+                        "starkware.cairo.common.hash_state.hash_update.new_hash_state": 14
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 16,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 25,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 47,
+                                    "end_line": 40,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 33,
+                                    "start_line": 40
+                                },
+                                "While expanding the reference 'new_hash_state' in:"
+                            ],
+                            "start_col": 11,
+                            "start_line": 37
+                        },
+                        "While expanding the reference '__fp__' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 36
+                }
+            },
+            "32": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update.__fp__": 13,
+                        "starkware.cairo.common.hash_state.hash_update.__temp0": 15,
+                        "starkware.cairo.common.hash_state.hash_update.data_length": 9,
+                        "starkware.cairo.common.hash_state.hash_update.data_ptr": 8,
+                        "starkware.cairo.common.hash_state.hash_update.hash": 12,
+                        "starkware.cairo.common.hash_state.hash_update.hash_ptr": 11,
+                        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": 7,
+                        "starkware.cairo.common.hash_state.hash_update.new_hash_state": 14
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 40,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 40
+                }
+            },
+            "33": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 18,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 48,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 48
+                }
+            },
+            "35": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 18,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 45,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 34,
+                            "end_line": 13,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 62,
+                                    "end_line": 49,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 18,
+                                    "start_line": 49
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 13
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 45
+                }
+            },
+            "36": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 18,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 53,
+                    "end_line": 49,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 26,
+                    "start_line": 49
+                }
+            },
+            "37": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 18,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 81,
+                    "end_line": 45,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 61,
+                            "end_line": 49,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 57,
+                            "start_line": 49
+                        },
+                        "While expanding the reference 'item' in:"
+                    ],
+                    "start_col": 77,
+                    "start_line": 45
+                }
+            },
+            "38": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 18,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 62,
+                    "end_line": 49,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 49
+                }
+            },
+            "40": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.hash": 20,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 19,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 50,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 50
+                }
+            },
+            "42": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.__fp__": 21,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash": 20,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 19,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17,
+                        "starkware.cairo.common.hash_state.hash_update_single.new_hash_state": 22
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 52,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 52
+                }
+            },
+            "43": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.__fp__": 21,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash": 20,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 19,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17,
+                        "starkware.cairo.common.hash_state.hash_update_single.new_hash_state": 22
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 59,
+                    "end_line": 53,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 37,
+                    "start_line": 53
+                }
+            },
+            "44": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.__fp__": 21,
+                        "starkware.cairo.common.hash_state.hash_update_single.__temp1": 23,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash": 20,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 19,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17,
+                        "starkware.cairo.common.hash_state.hash_update_single.new_hash_state": 22
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 64,
+                    "end_line": 53,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 53
+                }
+            },
+            "46": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.__fp__": 21,
+                        "starkware.cairo.common.hash_state.hash_update_single.__temp1": 23,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash": 20,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 19,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17,
+                        "starkware.cairo.common.hash_state.hash_update_single.new_hash_state": 22
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 34,
+                    "end_line": 13,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 62,
+                            "end_line": 49,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 47,
+                                    "end_line": 45,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 49,
+                                            "end_line": 54,
+                                            "input_file": {
+                                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 54
+                                        },
+                                        "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                                    ],
+                                    "start_col": 25,
+                                    "start_line": 45
+                                },
+                                "While expanding the reference 'hash_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 49
+                        },
+                        "While trying to update the implicit return value 'hash_ptr' in:"
+                    ],
+                    "start_col": 12,
+                    "start_line": 13
+                }
+            },
+            "47": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.__fp__": 21,
+                        "starkware.cairo.common.hash_state.hash_update_single.__temp1": 23,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash": 20,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 19,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17,
+                        "starkware.cairo.common.hash_state.hash_update_single.new_hash_state": 22
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 16,
+                    "end_line": 50,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 25,
+                            "end_line": 51,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 47,
+                                    "end_line": 54,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 33,
+                                    "start_line": 54
+                                },
+                                "While expanding the reference 'new_hash_state' in:"
+                            ],
+                            "start_col": 11,
+                            "start_line": 51
+                        },
+                        "While expanding the reference '__fp__' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 50
+                }
+            },
+            "48": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_single"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_single.__fp__": 21,
+                        "starkware.cairo.common.hash_state.hash_update_single.__temp1": 23,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash": 20,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": 19,
+                        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": 16,
+                        "starkware.cairo.common.hash_state.hash_update_single.item": 17,
+                        "starkware.cairo.common.hash_state.hash_update_single.new_hash_state": 22
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 54,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 54
+                }
+            },
+            "49": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 27,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 55,
+                    "end_line": 59,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 124,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 69,
+                                    "end_line": 63,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 24,
+                                    "start_line": 63
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 17,
+                            "start_line": 124
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 33,
+                    "start_line": 59
+                }
+            },
+            "50": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 27,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 48,
+                    "end_line": 60,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 48,
+                            "end_line": 63,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 40,
+                            "start_line": 63
+                        },
+                        "While expanding the reference 'data_ptr' in:"
+                    ],
+                    "start_col": 33,
+                    "start_line": 60
+                }
+            },
+            "51": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 27,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 67,
+                    "end_line": 60,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 68,
+                            "end_line": 63,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 57,
+                            "start_line": 63
+                        },
+                        "While expanding the reference 'data_length' in:"
+                    ],
+                    "start_col": 50,
+                    "start_line": 60
+                }
+            },
+            "52": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 6,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 27,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 69,
+                    "end_line": 63,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 63
+                }
+            },
+            "54": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash": 29,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 28,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 124,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 69,
+                            "end_line": 63,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 47,
+                                    "end_line": 45,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 72,
+                                            "end_line": 66,
+                                            "input_file": {
+                                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                            },
+                                            "start_col": 12,
+                                            "start_line": 66
+                                        },
+                                        "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                                    ],
+                                    "start_col": 25,
+                                    "start_line": 45
+                                },
+                                "While expanding the reference 'hash_ptr' in:"
+                            ],
+                            "start_col": 24,
+                            "start_line": 63
+                        },
+                        "While trying to update the implicit return value 'hash_ptr' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 124
+                }
+            },
+            "55": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash": 29,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 28,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 60,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 60,
+                            "end_line": 66,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 46,
+                            "start_line": 66
+                        },
+                        "While expanding the reference 'hash_state_ptr' in:"
+                    ],
+                    "start_col": 5,
+                    "start_line": 60
+                }
+            },
+            "56": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash": 29,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 28,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 63,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 71,
+                            "end_line": 66,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 67,
+                            "start_line": 66
+                        },
+                        "While expanding the reference 'hash' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 63
+                }
+            },
+            "57": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash": 29,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 28,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 72,
+                    "end_line": 66,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 66
+                }
+            },
+            "59": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_with_hashchain"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 7,
+                        "offset": 19
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": 26,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": 25,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash": 29,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": 30,
+                        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": 24
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 73,
+                    "end_line": 66,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 66
+                }
+            },
+            "60": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_finalize"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_ptr": 32,
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_state_ptr": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 70,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 34,
+                            "end_line": 13,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 80,
+                                    "end_line": 71,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 18,
+                                    "start_line": 71
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 12,
+                            "start_line": 13
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 20,
+                    "start_line": 70
+                }
+            },
+            "61": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_finalize"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_ptr": 32,
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_state_ptr": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 53,
+                    "end_line": 71,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 26,
+                    "start_line": 71
+                }
+            },
+            "62": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_finalize"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_ptr": 32,
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_state_ptr": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 79,
+                    "end_line": 71,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 57,
+                    "start_line": 71
+                }
+            },
+            "63": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_finalize"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_ptr": 32,
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_state_ptr": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 80,
+                    "end_line": 71,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 71
+                }
+            },
+            "65": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_finalize"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 8,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_finalize.hash": 34,
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_ptr": 33,
+                        "starkware.cairo.common.hash_state.hash_finalize.hash_state_ptr": 31
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 72,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 72
+                }
+            },
+            "66": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 81
+                }
+            },
+            "68": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 78,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 46,
+                            "end_line": 78,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 28,
+                                    "end_line": 82,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 82
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 24,
+                            "start_line": 78
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 24,
+                    "start_line": 78
+                }
+            },
+            "69": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 94,
+                    "end_line": 78,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 82,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 22,
+                            "start_line": 82
+                        },
+                        "While expanding the reference 'hash' in:"
+                    ],
+                    "start_col": 84,
+                    "start_line": 78
+                }
+            },
+            "70": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 82
+                }
+            },
+            "71": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 86,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 86
+                }
+            },
+            "73": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 87,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 87
+                }
+            },
+            "75": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 87,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 87
+                }
+            },
+            "76": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 96,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 96
+                }
+            },
+            "77": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 97,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 97
+                }
+            },
+            "78": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 98,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 98
+                }
+            },
+            "79": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 72,
+                    "end_line": 103,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 36,
+                    "start_line": 103
+                }
+            },
+            "80": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38,
+                        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": 43,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 106,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 106
+                }
+            },
+            "81": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38,
+                        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": 43,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 59,
+                    "end_line": 107,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 37,
+                    "start_line": 107
+                }
+            },
+            "82": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp3": 44,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38,
+                        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": 43,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 107,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 107
+                }
+            },
+            "83": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp3": 44,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38,
+                        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": 43,
+                        "starkware.cairo.common.hash_state.hash_update_inner.next_locals": 45,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 58,
+                    "end_line": 111,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 111
+                }
+            },
+            "85": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp3": 44,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38,
+                        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": 43,
+                        "starkware.cairo.common.hash_state.hash_update_inner.next_locals": 45,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 73,
+                    "end_line": 112,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 112
+                }
+            },
+            "87": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp3": 44,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38,
+                        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": 43,
+                        "starkware.cairo.common.hash_state.hash_update_inner.next_locals": 45,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 113,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 113
+                }
+            },
+            "88": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp3": 44,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 38,
+                        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": 43,
+                        "starkware.cairo.common.hash_state.hash_update_inner.next_locals": 45,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 116,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 116
+                }
+            },
+            "90": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_update_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 9,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": 39,
+                        "starkware.cairo.common.hash_state.hash_update_inner.__temp3": 44,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": 40,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_length": 36,
+                        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": 35,
+                        "starkware.cairo.common.hash_state.hash_update_inner.final_locals": 46,
+                        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": 41,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash": 37,
+                        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": 47,
+                        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": 43,
+                        "starkware.cairo.common.hash_state.hash_update_inner.next_locals": 45,
+                        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": 42
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 121,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 121
+                }
+            },
+            "91": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_felts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_felts.data": 48,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": 50,
+                        "starkware.cairo.common.hash_state.hash_felts.length": 49
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 125,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 40,
+                    "start_line": 125
+                }
+            },
+            "93": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_felts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_felts.data": 48,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": 50,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr": 51,
+                        "starkware.cairo.common.hash_state.hash_felts.length": 49
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 124,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 40,
+                            "end_line": 29,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 128,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "start_col": 28,
+                                    "start_line": 126
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 18,
+                            "start_line": 29
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 124
+                }
+            },
+            "94": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_felts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_felts.data": 48,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": 50,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr": 51,
+                        "starkware.cairo.common.hash_state.hash_felts.length": 49
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 125,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 127,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 24,
+                            "start_line": 127
+                        },
+                        "While expanding the reference 'hash_state_ptr' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 125
+                }
+            },
+            "95": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_felts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_felts.data": 48,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": 50,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr": 51,
+                        "starkware.cairo.common.hash_state.hash_felts.length": 49
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 52,
+                    "end_line": 124,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 53,
+                            "end_line": 127,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 49,
+                            "start_line": 127
+                        },
+                        "While expanding the reference 'data' in:"
+                    ],
+                    "start_col": 41,
+                    "start_line": 124
+                }
+            },
+            "96": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_felts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_felts.data": 48,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": 50,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr": 51,
+                        "starkware.cairo.common.hash_state.hash_felts.length": 49
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 66,
+                    "end_line": 124,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 73,
+                            "end_line": 127,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "start_col": 67,
+                            "start_line": 127
+                        },
+                        "While expanding the reference 'length' in:"
+                    ],
+                    "start_col": 54,
+                    "start_line": 124
+                }
+            },
+            "97": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_felts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 10,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_felts.data": 48,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": 50,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr": 51,
+                        "starkware.cairo.common.hash_state.hash_felts.length": 49
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 128,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 126
+                }
+            },
+            "99": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_felts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 11,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_felts.data": 48,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": 52,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr": 53,
+                        "starkware.cairo.common.hash_state.hash_felts.length": 49
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 129,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 129
+                }
+            },
+            "101": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.hash_state",
+                    "starkware.cairo.common.hash_state.hash_felts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 11,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.hash_state.hash_felts.data": 48,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": 54,
+                        "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr": 53,
+                        "starkware.cairo.common.hash_state.hash_felts.length": 49
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 57,
+                    "end_line": 129,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 129
+                }
+            },
+            "102": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 184,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 164
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 186,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 186
+                }
+            },
+            "103": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 66,
+                    "end_line": 186,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 45,
+                    "start_line": 186
+                }
+            },
+            "104": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 86,
+                    "end_line": 186,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 45,
+                    "start_line": 186
+                }
+            },
+            "106": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 86,
+                    "end_line": 186,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 186
+                }
+            },
+            "107": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 45,
+                    "end_line": 187,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 187
+                }
+            },
+            "108": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 69,
+                    "end_line": 187,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 48,
+                    "start_line": 187
+                }
+            },
+            "109": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 89,
+                    "end_line": 187,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 48,
+                    "start_line": 187
+                }
+            },
+            "111": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 89,
+                    "end_line": 187,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 187
+                }
+            },
+            "112": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 49,
+                            "end_line": 196,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 196
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 197,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 197
+                }
+            },
+            "114": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 198,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 198
+                }
+            },
+            "116": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 69,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 198,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 198
+                }
+            },
+            "117": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 69,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 70,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 198,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 198
+                }
+            },
+            "118": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 69,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 70,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 199
+                }
+            },
+            "119": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 69,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 70,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 71,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 199
+                }
+            },
+            "121": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 69,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 70,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 71,
+                        "starkware.cairo.common.math.assert_le_felt.__temp13": 72,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 199
+                }
+            },
+            "122": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 69,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 70,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 71,
+                        "starkware.cairo.common.math.assert_le_felt.__temp13": 72,
+                        "starkware.cairo.common.math.assert_le_felt.__temp14": 73,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 199
+                }
+            },
+            "123": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 69,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 70,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 71,
+                        "starkware.cairo.common.math.assert_le_felt.__temp13": 72,
+                        "starkware.cairo.common.math.assert_le_felt.__temp14": 73,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 188,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 154,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 200,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 200
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 154
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 188
+                }
+            },
+            "125": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 15
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp10": 69,
+                        "starkware.cairo.common.math.assert_le_felt.__temp11": 70,
+                        "starkware.cairo.common.math.assert_le_felt.__temp12": 71,
+                        "starkware.cairo.common.math.assert_le_felt.__temp13": 72,
+                        "starkware.cairo.common.math.assert_le_felt.__temp14": 73,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 200,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 200
+                }
+            },
+            "126": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 49,
+                            "end_line": 204,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 204
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 205,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 205
+                }
+            },
+            "128": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 206,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 206
+                }
+            },
+            "130": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 74,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 206,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 206
+                }
+            },
+            "131": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 74,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 75,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 207,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 207
+                }
+            },
+            "132": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 74,
+                        "starkware.cairo.common.math.assert_le_felt.__temp16": 76,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 75,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 207,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 207
+                }
+            },
+            "133": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 13
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 74,
+                        "starkware.cairo.common.math.assert_le_felt.__temp16": 76,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 75,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 208,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 208
+                }
+            },
+            "134": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 74,
+                        "starkware.cairo.common.math.assert_le_felt.__temp16": 76,
+                        "starkware.cairo.common.math.assert_le_felt.__temp17": 77,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 75,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 208,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 208
+                }
+            },
+            "135": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 74,
+                        "starkware.cairo.common.math.assert_le_felt.__temp16": 76,
+                        "starkware.cairo.common.math.assert_le_felt.__temp17": 77,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 75,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 188,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 154,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 209,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 209
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 154
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 188
+                }
+            },
+            "137": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 15
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp15": 74,
+                        "starkware.cairo.common.math.assert_le_felt.__temp16": 76,
+                        "starkware.cairo.common.math.assert_le_felt.__temp17": 77,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.m1mb": 75,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 209,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 209
+                }
+            },
+            "138": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 31,
+                            "end_line": 213,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 213
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 214,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 214
+                }
+            },
+            "139": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 215,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 215
+                }
+            },
+            "140": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 11
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp18": 78,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 34,
+                    "end_line": 215,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 215
+                }
+            },
+            "141": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp18": 78,
+                        "starkware.cairo.common.math.assert_le_felt.__temp19": 79,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 35,
+                    "end_line": 215,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 215
+                }
+            },
+            "142": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 12
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp18": 78,
+                        "starkware.cairo.common.math.assert_le_felt.__temp19": 79,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 12,
+                    "end_line": 216,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 216
+                }
+            },
+            "144": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 14
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp18": 78,
+                        "starkware.cairo.common.math.assert_le_felt.__temp19": 79,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 188,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 154,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 217,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 217
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 154
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 27,
+                    "start_line": 188
+                }
+            },
+            "146": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 15
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp18": 78,
+                        "starkware.cairo.common.math.assert_le_felt.__temp19": 79,
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 217,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 217
+                }
+            },
+            "147": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 82
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 230,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 224
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 231,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 231
+                }
+            },
+            "148": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.__temp20": 83,
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 82
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 231,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 231
+                }
+            },
+            "150": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.__temp20": 83,
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 82
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 233,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 233
+                }
+            },
+            "152": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.__temp20": 83,
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 82
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 223,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 154,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 25,
+                                    "end_line": 235,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 235
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 154
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 21,
+                    "start_line": 223
+                }
+            },
+            "153": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.__temp20": 83,
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 82
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 223,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 21,
+                            "end_line": 235,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 235
+                        },
+                        "While expanding the reference 'a' in:"
+                    ],
+                    "start_col": 38,
+                    "start_line": 223
+                }
+            },
+            "154": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.__temp20": 83,
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 82
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 223,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 24,
+                            "end_line": 235,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "start_col": 23,
+                            "start_line": 235
+                        },
+                        "While expanding the reference 'b' in:"
+                    ],
+                    "start_col": 41,
+                    "start_line": 223
+                }
+            },
+            "155": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.__temp20": 83,
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 82
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 235,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 235
+                }
+            },
+            "157": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 21
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.__temp20": 83,
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 84
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 236,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 236
+                }
+            },
+            "158": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 14,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 87
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 58,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 58
+                }
+            },
+            "160": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 14,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 87
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 43,
+                            "end_line": 55,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 19,
+                                    "end_line": 59,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 59
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 28,
+                            "start_line": 55
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 28,
+                    "start_line": 55
+                }
+            },
+            "161": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 14,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 87
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 59,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 59
+                }
+            },
+            "162": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 14,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 87
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 49,
+                            "end_line": 70,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 66,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 12,
+                                    "start_line": 62
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 34,
+                            "start_line": 70
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 28,
+                    "start_line": 55
+                }
+            },
+            "163": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 14,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 87
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 63,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 63
+                }
+            },
+            "165": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 14,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 87
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 64,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 64
+                }
+            },
+            "167": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 14,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 87
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 65,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 65
+                }
+            },
+            "168": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 14,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 87
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 66,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 62
+                }
+            },
+            "170": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 15,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points.entry_points": 86,
+                        "__main__.validate_entry_points.n_entry_points": 85,
+                        "__main__.validate_entry_points.range_check_ptr": 88
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 66,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 62
+                }
+            },
+            "171": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 92
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 73,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 73
+                }
+            },
+            "173": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 92
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 70,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 49,
+                            "end_line": 70,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 19,
+                                    "end_line": 74,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 74
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 34,
+                            "start_line": 70
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 34,
+                    "start_line": 70
+                }
+            },
+            "174": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 92
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 74,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 74
+                }
+            },
+            "175": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 92
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 70,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 223,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/math.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 57,
+                                    "end_line": 77,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 77
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 223
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 34,
+                    "start_line": 70
+                }
+            },
+            "176": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 92
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 71,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 33,
+                            "end_line": 77,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 77
+                        },
+                        "While expanding the reference 'prev_selector' in:"
+                    ],
+                    "start_col": 62,
+                    "start_line": 71
+                }
+            },
+            "177": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 92
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 77,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 35,
+                    "start_line": 77
+                }
+            },
+            "178": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 92
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 57,
+                    "end_line": 77,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 77
+                }
+            },
+            "180": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 26
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 93
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 80,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 80
+                }
+            },
+            "182": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 27
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 93
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 81,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 81
+                }
+            },
+            "184": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 28
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 93
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 82,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 23,
+                    "start_line": 82
+                }
+            },
+            "185": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 16,
+                        "offset": 29
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 93
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 79
+                }
+            },
+            "187": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.validate_entry_points_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 17,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.validate_entry_points_inner.entry_points": 90,
+                        "__main__.validate_entry_points_inner.n_entry_points": 89,
+                        "__main__.validate_entry_points_inner.prev_selector": 91,
+                        "__main__.validate_entry_points_inner.range_check_ptr": 94
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 83,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 79
+                }
+            },
+            "188": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 96
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 87,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 40,
+                    "start_line": 87
+                }
+            },
+            "190": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 96,
+                        "__main__.class_hash.hash_state_ptr": 97
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 86,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 47,
+                            "end_line": 45,
+                            "input_file": {
+                                "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 90,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 28,
+                                    "start_line": 88
+                                },
+                                "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                            ],
+                            "start_col": 25,
+                            "start_line": 45
+                        },
+                        "While expanding the reference 'hash_ptr' in:"
+                    ],
+                    "start_col": 17,
+                    "start_line": 86
+                }
+            },
+            "191": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 96,
+                        "__main__.class_hash.hash_state_ptr": 97
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 87,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 89,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 24,
+                            "start_line": 89
+                        },
+                        "While expanding the reference 'hash_state_ptr' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 87
+                }
+            },
+            "192": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 96,
+                        "__main__.class_hash.hash_state_ptr": 97
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 71,
+                    "end_line": 89,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 45,
+                    "start_line": 89
+                }
+            },
+            "193": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 96,
+                        "__main__.class_hash.hash_state_ptr": 97
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 90,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 88
+                }
+            },
+            "195": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 26
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 98,
+                        "__main__.class_hash.hash_state_ptr": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 56,
+                    "end_line": 96,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 96
+                }
+            },
+            "196": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 27
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 98,
+                        "__main__.class_hash.hash_state_ptr": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 45,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 6,
+                            "end_line": 90,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 55,
+                                    "end_line": 59,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 6,
+                                            "end_line": 97,
+                                            "input_file": {
+                                                "filename": "../cairo_programs/contracts.cairo"
+                                            },
+                                            "start_col": 28,
+                                            "start_line": 93
+                                        },
+                                        "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                                    ],
+                                    "start_col": 33,
+                                    "start_line": 59
+                                },
+                                "While expanding the reference 'hash_ptr' in:"
+                            ],
+                            "start_col": 28,
+                            "start_line": 88
+                        },
+                        "While trying to update the implicit return value 'hash_ptr' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 45
+                }
+            },
+            "197": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 28
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 98,
+                        "__main__.class_hash.hash_state_ptr": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 88,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 94,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 24,
+                            "start_line": 94
+                        },
+                        "While expanding the reference 'hash_state_ptr' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 88
+                }
+            },
+            "198": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 29
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 98,
+                        "__main__.class_hash.hash_state_ptr": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 95,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 95
+                }
+            },
+            "199": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 30
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 98,
+                        "__main__.class_hash.hash_state_ptr": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 82,
+                    "end_line": 96,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 96
+                }
+            },
+            "201": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 18,
+                        "offset": 31
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 98,
+                        "__main__.class_hash.hash_state_ptr": 99
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 97,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 93
+                }
+            },
+            "203": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 19,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 101,
+                        "__main__.class_hash.hash_state_ptr": 102
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 49,
+                    "end_line": 103,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 103
+                }
+            },
+            "204": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 19,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 101,
+                        "__main__.class_hash.hash_state_ptr": 102
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 55,
+                    "end_line": 59,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 6,
+                            "end_line": 97,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 55,
+                                    "end_line": 59,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 6,
+                                            "end_line": 104,
+                                            "input_file": {
+                                                "filename": "../cairo_programs/contracts.cairo"
+                                            },
+                                            "start_col": 28,
+                                            "start_line": 100
+                                        },
+                                        "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                                    ],
+                                    "start_col": 33,
+                                    "start_line": 59
+                                },
+                                "While expanding the reference 'hash_ptr' in:"
+                            ],
+                            "start_col": 28,
+                            "start_line": 93
+                        },
+                        "While trying to update the implicit return value 'hash_ptr' in:"
+                    ],
+                    "start_col": 33,
+                    "start_line": 59
+                }
+            },
+            "205": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 19,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 101,
+                        "__main__.class_hash.hash_state_ptr": 102
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 93,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 101,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 24,
+                            "start_line": 101
+                        },
+                        "While expanding the reference 'hash_state_ptr' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 93
+                }
+            },
+            "206": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 19,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 101,
+                        "__main__.class_hash.hash_state_ptr": 102
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 44,
+                    "end_line": 102,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 102
+                }
+            },
+            "207": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 19,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 101,
+                        "__main__.class_hash.hash_state_ptr": 102
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 103,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 103
+                }
+            },
+            "209": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 19,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 101,
+                        "__main__.class_hash.hash_state_ptr": 102
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 104,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 100
+                }
+            },
+            "211": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 20,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 104,
+                        "__main__.class_hash.hash_state_ptr": 105
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 110,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 110
+                }
+            },
+            "212": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 20,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 104,
+                        "__main__.class_hash.hash_state_ptr": 105
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 55,
+                    "end_line": 59,
+                    "input_file": {
+                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 6,
+                            "end_line": 104,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 55,
+                                    "end_line": 59,
+                                    "input_file": {
+                                        "filename": "/Users/aminarria/Lambda/starknet_in_rust/starknet-venv/lib/python3.9/site-packages/starkware/cairo/common/hash_state.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 6,
+                                            "end_line": 111,
+                                            "input_file": {
+                                                "filename": "../cairo_programs/contracts.cairo"
+                                            },
+                                            "start_col": 28,
+                                            "start_line": 107
+                                        },
+                                        "While trying to retrieve the implicit argument 'hash_ptr' in:"
+                                    ],
+                                    "start_col": 33,
+                                    "start_line": 59
+                                },
+                                "While expanding the reference 'hash_ptr' in:"
+                            ],
+                            "start_col": 28,
+                            "start_line": 100
+                        },
+                        "While trying to update the implicit return value 'hash_ptr' in:"
+                    ],
+                    "start_col": 33,
+                    "start_line": 59
+                }
+            },
+            "213": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 20,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 104,
+                        "__main__.class_hash.hash_state_ptr": 105
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 100,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 108,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 24,
+                            "start_line": 108
+                        },
+                        "While expanding the reference 'hash_state_ptr' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 100
+                }
+            },
+            "214": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 20,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 104,
+                        "__main__.class_hash.hash_state_ptr": 105
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 45,
+                    "end_line": 109,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 109
+                }
+            },
+            "215": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 20,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 104,
+                        "__main__.class_hash.hash_state_ptr": 105
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 76,
+                    "end_line": 110,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 110
+                }
+            },
+            "217": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 20,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 104,
+                        "__main__.class_hash.hash_state_ptr": 105
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 111,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 107
+                }
+            },
+            "219": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 21,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 107,
+                        "__main__.class_hash.hash_state_ptr": 108
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 45,
+                    "end_line": 116,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 116
+                }
+            },
+            "220": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 21,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 107,
+                        "__main__.class_hash.hash_state_ptr": 108
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 117,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 117
+                }
+            },
+            "221": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 21,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 107,
+                        "__main__.class_hash.hash_state_ptr": 108
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 118,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 114
+                }
+            },
+            "223": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 22,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 109,
+                        "__main__.class_hash.hash_state_ptr": 110
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 77,
+                    "end_line": 122,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 45,
+                    "start_line": 122
+                }
+            },
+            "224": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 22,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 109,
+                        "__main__.class_hash.hash_state_ptr": 110
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 123,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 121
+                }
+            },
+            "226": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 22,
+                        "offset": 17
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 111,
+                        "__main__.class_hash.hash_state_ptr": 112
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 45,
+                    "end_line": 128,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 128
+                }
+            },
+            "227": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 22,
+                        "offset": 18
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 111,
+                        "__main__.class_hash.hash_state_ptr": 112
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 129,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 129
+                }
+            },
+            "228": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 22,
+                        "offset": 19
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 111,
+                        "__main__.class_hash.hash_state_ptr": 112
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 130,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 126
+                }
+            },
+            "230": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash_ptr": 113,
+                        "__main__.class_hash.hash_state_ptr": 114
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 68,
+                    "end_line": 132,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 132
+                }
+            },
+            "232": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.class_hash"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 23,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "__main__.class_hash.__temp21": 100,
+                        "__main__.class_hash.__temp22": 103,
+                        "__main__.class_hash.__temp23": 106,
+                        "__main__.class_hash.contract_class": 95,
+                        "__main__.class_hash.hash": 116,
+                        "__main__.class_hash.hash_ptr": 115,
+                        "__main__.class_hash.hash_state_ptr": 114
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 133,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 133
+                }
+            },
+            "233": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.pedersen_ptr": 117,
+                        "__main__.load_contract_class_facts.range_check_ptr": 118
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 149,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 149
+                }
+            },
+            "235": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 24,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 117,
+                        "__main__.load_contract_class_facts.range_check_ptr": 118
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 158,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 152
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 58,
+                    "end_line": 146,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 64,
+                            "end_line": 172,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 162,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 160
+                                },
+                                "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                            ],
+                            "start_col": 38,
+                            "start_line": 172
+                        },
+                        "While expanding the reference 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 32,
+                    "start_line": 146
+                }
+            },
+            "236": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 24,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 117,
+                        "__main__.load_contract_class_facts.range_check_ptr": 118
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 146,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 81,
+                            "end_line": 172,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 162,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 160
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 66,
+                            "start_line": 172
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 60,
+                    "start_line": 146
+                }
+            },
+            "237": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 24,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 117,
+                        "__main__.load_contract_class_facts.range_check_ptr": 118
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 150,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 54,
+                            "end_line": 161,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 32,
+                            "start_line": 161
+                        },
+                        "While expanding the reference 'n_contract_class_facts' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 150
+                }
+            },
+            "238": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 24,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 117,
+                        "__main__.load_contract_class_facts.range_check_ptr": 118
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 151,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 97,
+                            "end_line": 161,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 77,
+                            "start_line": 161
+                        },
+                        "While expanding the reference 'contract_class_facts' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 151
+                }
+            },
+            "239": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 24,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 117,
+                        "__main__.load_contract_class_facts.range_check_ptr": 118
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 162,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 160
+                }
+            },
+            "241": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 25,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 121,
+                        "__main__.load_contract_class_facts.range_check_ptr": 122
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 26,
+                            "end_line": 163,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 163
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 33,
+                    "end_line": 150,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 54,
+                            "end_line": 166,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 32,
+                            "start_line": 166
+                        },
+                        "While expanding the reference 'n_contract_class_facts' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 150
+                }
+            },
+            "242": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 25,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 121,
+                        "__main__.load_contract_class_facts.range_check_ptr": 122
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 151,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 97,
+                            "end_line": 166,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 77,
+                            "start_line": 166
+                        },
+                        "While expanding the reference 'contract_class_facts' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 151
+                }
+            },
+            "243": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 25,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 121,
+                        "__main__.load_contract_class_facts.range_check_ptr": 122
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 167,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 165
+                }
+            },
+            "244": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 175,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 175
+                }
+            },
+            "246": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 64,
+                    "end_line": 172,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 64,
+                            "end_line": 172,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 19,
+                                    "end_line": 176,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 176
+                                },
+                                "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                            ],
+                            "start_col": 38,
+                            "start_line": 172
+                        },
+                        "While expanding the reference 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 38,
+                    "start_line": 172
+                }
+            },
+            "247": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 81,
+                    "end_line": 172,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 81,
+                            "end_line": 172,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 19,
+                                    "end_line": 176,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 9,
+                                    "start_line": 176
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 66,
+                            "start_line": 172
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 66,
+                    "start_line": 172
+                }
+            },
+            "248": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 176,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 176
+                }
+            },
+            "249": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 178,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 178
+                }
+            },
+            "251": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 192,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 184
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 181,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 38,
+                            "end_line": 194,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 12,
+                            "start_line": 194
+                        },
+                        "While expanding the reference 'contract_class.api_version' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 181
+                }
+            },
+            "252": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 52,
+                    "end_line": 194,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 41,
+                    "start_line": 194
+                }
+            },
+            "254": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 53,
+                    "end_line": 194,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 194
+                }
+            },
+            "255": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 181,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 59,
+                            "end_line": 197,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 24,
+                            "start_line": 197
+                        },
+                        "While expanding the reference 'contract_class.n_external_functions' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 181
+                }
+            },
+            "256": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 181,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 55,
+                            "end_line": 198,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 22,
+                            "start_line": 198
+                        },
+                        "While expanding the reference 'contract_class.external_functions' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 181
+                }
+            },
+            "257": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 81,
+                    "end_line": 172,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 43,
+                            "end_line": 55,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 199,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 196
+                                },
+                                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                            ],
+                            "start_col": 28,
+                            "start_line": 55
+                        },
+                        "While expanding the reference 'range_check_ptr' in:"
+                    ],
+                    "start_col": 66,
+                    "start_line": 172
+                }
+            },
+            "258": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 59,
+                    "end_line": 197,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 197
+                }
+            },
+            "259": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 55,
+                    "end_line": 198,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 198
+                }
+            },
+            "260": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 199,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 196
+                }
+            },
+            "262": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 27,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 133
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 181,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 52,
+                            "end_line": 202,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 24,
+                            "start_line": 202
+                        },
+                        "While expanding the reference 'contract_class.n_l1_handlers' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 181
+                }
+            },
+            "263": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 27,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 133
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 181,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 93,
+                            "end_line": 202,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 67,
+                            "start_line": 202
+                        },
+                        "While expanding the reference 'contract_class.l1_handlers' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 181
+                }
+            },
+            "264": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 27,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 133
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 6,
+                            "end_line": 199,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 43,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 6,
+                                            "end_line": 203,
+                                            "input_file": {
+                                                "filename": "../cairo_programs/contracts.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 201
+                                        },
+                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 28,
+                                    "start_line": 55
+                                },
+                                "While expanding the reference 'range_check_ptr' in:"
+                            ],
+                            "start_col": 5,
+                            "start_line": 196
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 28,
+                    "start_line": 55
+                }
+            },
+            "265": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 27,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 133
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 52,
+                    "end_line": 202,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 202
+                }
+            },
+            "266": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 27,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 133
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 93,
+                    "end_line": 202,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 67,
+                    "start_line": 202
+                }
+            },
+            "267": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 27,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 133
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 203,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 201
+                }
+            },
+            "269": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 28,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 136
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 6,
+                            "end_line": 203,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 43,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 6,
+                                            "end_line": 203,
+                                            "input_file": {
+                                                "filename": "../cairo_programs/contracts.cairo"
+                                            },
+                                            "start_col": 5,
+                                            "start_line": 201
+                                        },
+                                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 28,
+                                    "start_line": 55
+                                },
+                                "While auto generating local variable for 'range_check_ptr'."
+                            ],
+                            "start_col": 5,
+                            "start_line": 201
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 28,
+                    "start_line": 55
+                }
+            },
+            "270": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 28,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 64,
+                    "end_line": 172,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 50,
+                            "end_line": 205,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 38,
+                            "start_line": 205
+                        },
+                        "While expanding the reference 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 38,
+                    "start_line": 172
+                }
+            },
+            "271": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 28,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 60,
+                    "end_line": 181,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 66,
+                            "end_line": 205,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 52,
+                            "start_line": 205
+                        },
+                        "While expanding the reference 'contract_class' in:"
+                    ],
+                    "start_col": 26,
+                    "start_line": 181
+                }
+            },
+            "272": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 28,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 67,
+                    "end_line": 205,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 18,
+                    "start_line": 205
+                }
+            },
+            "274": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 29,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.hash": 139,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 138,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 206,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 206
+                }
+            },
+            "275": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 29,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.hash": 139,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 138,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 218,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 208
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 205,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 64,
+                            "end_line": 172,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 6,
+                                    "end_line": 223,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "start_col": 12,
+                                    "start_line": 220
+                                },
+                                "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+                            ],
+                            "start_col": 38,
+                            "start_line": 172
+                        },
+                        "While expanding the reference 'pedersen_ptr' in:"
+                    ],
+                    "start_col": 38,
+                    "start_line": 205
+                }
+            },
+            "276": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 29,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.hash": 139,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 138,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 43,
+                    "end_line": 55,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 6,
+                            "end_line": 203,
+                            "input_file": {
+                                "filename": "../cairo_programs/contracts.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 43,
+                                    "end_line": 55,
+                                    "input_file": {
+                                        "filename": "../cairo_programs/contracts.cairo"
+                                    },
+                                    "parent_location": [
+                                        {
+                                            "end_col": 6,
+                                            "end_line": 203,
+                                            "input_file": {
+                                                "filename": "../cairo_programs/contracts.cairo"
+                                            },
+                                            "parent_location": [
+                                                {
+                                                    "end_col": 81,
+                                                    "end_line": 172,
+                                                    "input_file": {
+                                                        "filename": "../cairo_programs/contracts.cairo"
+                                                    },
+                                                    "parent_location": [
+                                                        {
+                                                            "end_col": 6,
+                                                            "end_line": 223,
+                                                            "input_file": {
+                                                                "filename": "../cairo_programs/contracts.cairo"
+                                                            },
+                                                            "start_col": 12,
+                                                            "start_line": 220
+                                                        },
+                                                        "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+                                                    ],
+                                                    "start_col": 66,
+                                                    "start_line": 172
+                                                },
+                                                "While expanding the reference 'range_check_ptr' in:"
+                                            ],
+                                            "start_col": 5,
+                                            "start_line": 201
+                                        },
+                                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                                    ],
+                                    "start_col": 28,
+                                    "start_line": 55
+                                },
+                                "While auto generating local variable for 'range_check_ptr'."
+                            ],
+                            "start_col": 5,
+                            "start_line": 201
+                        },
+                        "While trying to update the implicit return value 'range_check_ptr' in:"
+                    ],
+                    "start_col": 28,
+                    "start_line": 55
+                }
+            },
+            "277": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 29,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.hash": 139,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 138,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 58,
+                    "end_line": 221,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 32,
+                    "start_line": 221
+                }
+            },
+            "279": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 29,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.hash": 139,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 138,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 75,
+                    "end_line": 222,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 30,
+                    "start_line": 222
+                }
+            },
+            "281": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 29,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.hash": 139,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 138,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 223,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 220
+                }
+            },
+            "283": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 30,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.hash": 139,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 140,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 141
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 223,
+                    "input_file": {
+                        "filename": "../cairo_programs/contracts.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 220
+                }
+            }
+        }
+    },
+    "hints": {
+        "102": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "code": "import itertools\n\nfrom starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\na = ids.a % PRIME\nb = ids.b % PRIME\nassert a <= b, f'a = {a} is not less than or equal to b = {b}.'\n\n# Find an arc less than PRIME / 3, and another less than PRIME / 2.\nlengths_and_indices = [(a, 0), (b - a, 1), (PRIME - 1 - b, 2)]\nlengths_and_indices.sort()\nassert lengths_and_indices[0][0] <= PRIME // 3 and lengths_and_indices[1][0] <= PRIME // 2\nexcluded = lengths_and_indices[2][1]\n\nmemory[ids.range_check_ptr + 1], memory[ids.range_check_ptr + 0] = (\n    divmod(lengths_and_indices[0][0], ids.PRIME_OVER_3_HIGH))\nmemory[ids.range_check_ptr + 3], memory[ids.range_check_ptr + 2] = (\n    divmod(lengths_and_indices[1][0], ids.PRIME_OVER_2_HIGH))",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 57
+                    }
+                }
+            }
+        ],
+        "112": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "code": "memory[ap] = 1 if excluded != 0 else 0",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                }
+            }
+        ],
+        "126": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "code": "memory[ap] = 1 if excluded != 1 else 0",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 9
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                }
+            }
+        ],
+        "138": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_le_felt"
+                ],
+                "code": "assert excluded == 2",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 12,
+                        "offset": 10
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_le_felt.__temp4": 58,
+                        "starkware.cairo.common.math.assert_le_felt.__temp5": 59,
+                        "starkware.cairo.common.math.assert_le_felt.__temp6": 60,
+                        "starkware.cairo.common.math.assert_le_felt.__temp7": 62,
+                        "starkware.cairo.common.math.assert_le_felt.__temp8": 63,
+                        "starkware.cairo.common.math.assert_le_felt.__temp9": 64,
+                        "starkware.cairo.common.math.assert_le_felt.a": 55,
+                        "starkware.cairo.common.math.assert_le_felt.arc_long": 65,
+                        "starkware.cairo.common.math.assert_le_felt.arc_prod": 68,
+                        "starkware.cairo.common.math.assert_le_felt.arc_short": 61,
+                        "starkware.cairo.common.math.assert_le_felt.arc_sum": 67,
+                        "starkware.cairo.common.math.assert_le_felt.b": 56,
+                        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": 66
+                    }
+                }
+            }
+        ],
+        "147": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.math",
+                    "starkware.cairo.common.math.assert_lt_felt"
+                ],
+                "code": "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.math.assert_lt_felt.a": 80,
+                        "starkware.cairo.common.math.assert_lt_felt.b": 81,
+                        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": 82
+                    }
+                }
+            }
+        ],
+        "235": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "code": "ids.contract_class_facts = segments.add()\nids.n_contract_class_facts = len(os_input.contract_definitions)\nvm_enter_scope({\n    'contract_class_facts': iter(os_input.contract_definitions.items()),\n})",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 24,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 117,
+                        "__main__.load_contract_class_facts.range_check_ptr": 118
+                    }
+                }
+            }
+        ],
+        "241": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts"
+                ],
+                "code": "vm_exit_scope()",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 25,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts.contract_class_facts": 120,
+                        "__main__.load_contract_class_facts.n_contract_class_facts": 119,
+                        "__main__.load_contract_class_facts.pedersen_ptr": 121,
+                        "__main__.load_contract_class_facts.range_check_ptr": 122
+                    }
+                }
+            }
+        ],
+        "251": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "code": "from starkware.starknet.core.os.class_hash import get_contract_class_struct\n\nclass_hash, contract_class = next(contract_class_facts)\n\ncairo_contract = get_contract_class_struct(\n    identifiers=ids._context.identifiers, contract_class=contract_class)\nids.contract_class = segments.gen_arg(cairo_contract)",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 26,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 125,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 126
+                    }
+                }
+            }
+        ],
+        "275": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.load_contract_class_facts_inner"
+                ],
+                "code": "from starkware.python.utils import from_bytes\n\ncomputed_hash = ids.contract_class_fact.hash\nexpected_hash = from_bytes(class_hash)\nassert computed_hash == expected_hash, (\n    \"Computed class_hash is inconsistent with the hash in the os_input. \"\n    f\"Computed hash = {computed_hash}, Expected hash = {expected_hash}.\")\n\nvm_load_program(contract_class.program, ids.contract_class.bytecode_ptr)",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 29,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.load_contract_class_facts_inner.__temp24": 129,
+                        "__main__.load_contract_class_facts_inner.__temp25": 130,
+                        "__main__.load_contract_class_facts_inner.__temp26": 131,
+                        "__main__.load_contract_class_facts_inner.__temp27": 132,
+                        "__main__.load_contract_class_facts_inner.__temp28": 134,
+                        "__main__.load_contract_class_facts_inner.__temp29": 135,
+                        "__main__.load_contract_class_facts_inner.contract_class": 128,
+                        "__main__.load_contract_class_facts_inner.contract_class_fact": 127,
+                        "__main__.load_contract_class_facts_inner.contract_class_facts": 124,
+                        "__main__.load_contract_class_facts_inner.hash": 139,
+                        "__main__.load_contract_class_facts_inner.n_contract_class_facts": 123,
+                        "__main__.load_contract_class_facts_inner.pedersen_ptr": 138,
+                        "__main__.load_contract_class_facts_inner.range_check_ptr": 137
+                    }
+                }
+            }
+        ]
+    },
+    "identifiers": {
+        "__main__.API_VERSION": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.ContractClass": {
+            "full_name": "__main__.ContractClass",
+            "members": {
+                "api_version": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "builtin_list": {
+                    "cairo_type": "felt*",
+                    "offset": 8
+                },
+                "bytecode_length": {
+                    "cairo_type": "felt",
+                    "offset": 10
+                },
+                "bytecode_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 11
+                },
+                "constructors": {
+                    "cairo_type": "__main__.ContractEntryPoint*",
+                    "offset": 6
+                },
+                "external_functions": {
+                    "cairo_type": "__main__.ContractEntryPoint*",
+                    "offset": 2
+                },
+                "hinted_class_hash": {
+                    "cairo_type": "felt",
+                    "offset": 9
+                },
+                "l1_handlers": {
+                    "cairo_type": "__main__.ContractEntryPoint*",
+                    "offset": 4
+                },
+                "n_builtins": {
+                    "cairo_type": "felt",
+                    "offset": 7
+                },
+                "n_constructors": {
+                    "cairo_type": "felt",
+                    "offset": 5
+                },
+                "n_external_functions": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "n_l1_handlers": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                }
+            },
+            "size": 12,
+            "type": "struct"
+        },
+        "__main__.ContractClassFact": {
+            "full_name": "__main__.ContractClassFact",
+            "members": {
+                "contract_class": {
+                    "cairo_type": "__main__.ContractClass*",
+                    "offset": 1
+                },
+                "hash": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.ContractEntryPoint": {
+            "full_name": "__main__.ContractEntryPoint",
+            "members": {
+                "offset": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "selector": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.HashBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "type": "alias"
+        },
+        "__main__.HashState": {
+            "destination": "starkware.cairo.common.hash_state.HashState",
+            "type": "alias"
+        },
+        "__main__.assert_lt_felt": {
+            "destination": "starkware.cairo.common.math.assert_lt_felt",
+            "type": "alias"
+        },
+        "__main__.class_hash": {
+            "decorators": [],
+            "pc": 188,
+            "type": "function"
+        },
+        "__main__.class_hash.Args": {
+            "full_name": "__main__.class_hash.Args",
+            "members": {
+                "contract_class": {
+                    "cairo_type": "__main__.ContractClass*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "__main__.class_hash.ImplicitArgs": {
+            "full_name": "__main__.class_hash.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "__main__.class_hash.Return": {
+            "cairo_type": "(hash: felt)",
+            "type": "type_definition"
+        },
+        "__main__.class_hash.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.class_hash.__temp21": {
+            "cairo_type": "felt",
+            "full_name": "__main__.class_hash.__temp21",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 27
+                    },
+                    "pc": 196,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.class_hash.__temp22": {
+            "cairo_type": "felt",
+            "full_name": "__main__.class_hash.__temp22",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 1
+                    },
+                    "pc": 204,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.class_hash.__temp23": {
+            "cairo_type": "felt",
+            "full_name": "__main__.class_hash.__temp23",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 1
+                    },
+                    "pc": 212,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.class_hash.contract_class": {
+            "cairo_type": "__main__.ContractClass*",
+            "full_name": "__main__.class_hash.contract_class",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 0
+                    },
+                    "pc": 188,
+                    "value": "[cast(fp + (-3), __main__.ContractClass**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.class_hash.hash": {
+            "cairo_type": "felt",
+            "full_name": "__main__.class_hash.hash",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 9
+                    },
+                    "pc": 232,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.class_hash.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "__main__.class_hash.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 0
+                    },
+                    "pc": 188,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 26
+                    },
+                    "pc": 195,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 0
+                    },
+                    "pc": 203,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 0
+                    },
+                    "pc": 211,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 0
+                    },
+                    "pc": 219,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 0
+                    },
+                    "pc": 223,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 17
+                    },
+                    "pc": 226,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "pc": 230,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 9
+                    },
+                    "pc": 232,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.class_hash.hash_state_ptr": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+            "full_name": "__main__.class_hash.hash_state_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 7
+                    },
+                    "pc": 190,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 26
+                    },
+                    "pc": 195,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 0
+                    },
+                    "pc": 203,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 0
+                    },
+                    "pc": 211,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 0
+                    },
+                    "pc": 219,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 0
+                    },
+                    "pc": 223,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 17
+                    },
+                    "pc": 226,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "pc": 230,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.get_fp_and_pc": {
+            "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+            "type": "alias"
+        },
+        "__main__.hash_finalize": {
+            "destination": "starkware.cairo.common.hash_state.hash_finalize",
+            "type": "alias"
+        },
+        "__main__.hash_init": {
+            "destination": "starkware.cairo.common.hash_state.hash_init",
+            "type": "alias"
+        },
+        "__main__.hash_update": {
+            "destination": "starkware.cairo.common.hash_state.hash_update",
+            "type": "alias"
+        },
+        "__main__.hash_update_single": {
+            "destination": "starkware.cairo.common.hash_state.hash_update_single",
+            "type": "alias"
+        },
+        "__main__.hash_update_with_hashchain": {
+            "destination": "starkware.cairo.common.hash_state.hash_update_with_hashchain",
+            "type": "alias"
+        },
+        "__main__.load_contract_class_facts": {
+            "decorators": [],
+            "pc": 233,
+            "type": "function"
+        },
+        "__main__.load_contract_class_facts.Args": {
+            "full_name": "__main__.load_contract_class_facts.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.load_contract_class_facts.ImplicitArgs": {
+            "full_name": "__main__.load_contract_class_facts.ImplicitArgs",
+            "members": {
+                "pedersen_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                },
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.load_contract_class_facts.Return": {
+            "cairo_type": "(n_contract_class_facts: felt, contract_class_facts: __main__.ContractClassFact*)",
+            "type": "type_definition"
+        },
+        "__main__.load_contract_class_facts.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 2
+        },
+        "__main__.load_contract_class_facts.contract_class_facts": {
+            "cairo_type": "__main__.ContractClassFact*",
+            "full_name": "__main__.load_contract_class_facts.contract_class_facts",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 2
+                    },
+                    "pc": 235,
+                    "value": "[cast(fp + 1, __main__.ContractClassFact**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts.n_contract_class_facts": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts.n_contract_class_facts",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 2
+                    },
+                    "pc": 235,
+                    "value": "[cast(fp, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts.pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "__main__.load_contract_class_facts.pedersen_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 233,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 25,
+                        "offset": 0
+                    },
+                    "pc": 241,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 233,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 25,
+                        "offset": 0
+                    },
+                    "pc": 241,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner": {
+            "decorators": [],
+            "pc": 244,
+            "type": "function"
+        },
+        "__main__.load_contract_class_facts_inner.Args": {
+            "full_name": "__main__.load_contract_class_facts_inner.Args",
+            "members": {
+                "contract_class_facts": {
+                    "cairo_type": "__main__.ContractClassFact*",
+                    "offset": 1
+                },
+                "n_contract_class_facts": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.load_contract_class_facts_inner.ImplicitArgs": {
+            "full_name": "__main__.load_contract_class_facts_inner.ImplicitArgs",
+            "members": {
+                "pedersen_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                },
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.load_contract_class_facts_inner.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.load_contract_class_facts_inner.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 1
+        },
+        "__main__.load_contract_class_facts_inner.__temp24": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.__temp24",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 2
+                    },
+                    "pc": 252,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.__temp25": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.__temp25",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 3
+                    },
+                    "pc": 254,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.__temp26": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.__temp26",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 4
+                    },
+                    "pc": 256,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.__temp27": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.__temp27",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 5
+                    },
+                    "pc": 257,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.__temp28": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.__temp28",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 1
+                    },
+                    "pc": 263,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.__temp29": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.__temp29",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 2
+                    },
+                    "pc": 264,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.contract_class": {
+            "cairo_type": "__main__.ContractClass*",
+            "full_name": "__main__.load_contract_class_facts_inner.contract_class",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 1
+                    },
+                    "pc": 251,
+                    "value": "[cast([fp + (-3)] + 1, __main__.ContractClass**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.contract_class_fact": {
+            "cairo_type": "__main__.ContractClassFact*",
+            "full_name": "__main__.load_contract_class_facts_inner.contract_class_fact",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 1
+                    },
+                    "pc": 251,
+                    "value": "[cast(fp + (-3), __main__.ContractClassFact**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.contract_class_facts": {
+            "cairo_type": "__main__.ContractClassFact*",
+            "full_name": "__main__.load_contract_class_facts_inner.contract_class_facts",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 244,
+                    "value": "[cast(fp + (-3), __main__.ContractClassFact**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.hash": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.hash",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 29,
+                        "offset": 0
+                    },
+                    "pc": 274,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.n_contract_class_facts": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.n_contract_class_facts",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 244,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.pedersen_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "__main__.load_contract_class_facts_inner.pedersen_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 244,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 29,
+                        "offset": 0
+                    },
+                    "pc": 273,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 0
+                    },
+                    "pc": 282,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 29,
+                        "offset": 0
+                    },
+                    "pc": 274,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 0
+                    },
+                    "pc": 283,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.load_contract_class_facts_inner.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.load_contract_class_facts_inner.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 244,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 0
+                    },
+                    "pc": 262,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 0
+                    },
+                    "pc": 269,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 0
+                    },
+                    "pc": 282,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 0
+                    },
+                    "pc": 262,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 0
+                    },
+                    "pc": 269,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 0
+                    },
+                    "pc": 270,
+                    "value": "[cast(fp, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 0
+                    },
+                    "pc": 283,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.validate_entry_points": {
+            "decorators": [],
+            "pc": 158,
+            "type": "function"
+        },
+        "__main__.validate_entry_points.Args": {
+            "full_name": "__main__.validate_entry_points.Args",
+            "members": {
+                "entry_points": {
+                    "cairo_type": "__main__.ContractEntryPoint*",
+                    "offset": 1
+                },
+                "n_entry_points": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.validate_entry_points.ImplicitArgs": {
+            "full_name": "__main__.validate_entry_points.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "__main__.validate_entry_points.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.validate_entry_points.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.validate_entry_points.entry_points": {
+            "cairo_type": "__main__.ContractEntryPoint*",
+            "full_name": "__main__.validate_entry_points.entry_points",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 0
+                    },
+                    "pc": 158,
+                    "value": "[cast(fp + (-3), __main__.ContractEntryPoint**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.validate_entry_points.n_entry_points": {
+            "cairo_type": "felt",
+            "full_name": "__main__.validate_entry_points.n_entry_points",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 0
+                    },
+                    "pc": 158,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.validate_entry_points.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.validate_entry_points.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 0
+                    },
+                    "pc": 158,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 15,
+                        "offset": 0
+                    },
+                    "pc": 170,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.validate_entry_points_inner": {
+            "decorators": [],
+            "pc": 171,
+            "type": "function"
+        },
+        "__main__.validate_entry_points_inner.Args": {
+            "full_name": "__main__.validate_entry_points_inner.Args",
+            "members": {
+                "entry_points": {
+                    "cairo_type": "__main__.ContractEntryPoint*",
+                    "offset": 1
+                },
+                "n_entry_points": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "prev_selector": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.validate_entry_points_inner.ImplicitArgs": {
+            "full_name": "__main__.validate_entry_points_inner.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "__main__.validate_entry_points_inner.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.validate_entry_points_inner.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.validate_entry_points_inner.entry_points": {
+            "cairo_type": "__main__.ContractEntryPoint*",
+            "full_name": "__main__.validate_entry_points_inner.entry_points",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 0
+                    },
+                    "pc": 171,
+                    "value": "[cast(fp + (-4), __main__.ContractEntryPoint**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.validate_entry_points_inner.n_entry_points": {
+            "cairo_type": "felt",
+            "full_name": "__main__.validate_entry_points_inner.n_entry_points",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 0
+                    },
+                    "pc": 171,
+                    "value": "[cast(fp + (-5), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.validate_entry_points_inner.prev_selector": {
+            "cairo_type": "felt",
+            "full_name": "__main__.validate_entry_points_inner.prev_selector",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 0
+                    },
+                    "pc": 171,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.validate_entry_points_inner.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "__main__.validate_entry_points_inner.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 0
+                    },
+                    "pc": 171,
+                    "value": "[cast(fp + (-6), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 26
+                    },
+                    "pc": 180,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 17,
+                        "offset": 0
+                    },
+                    "pc": 187,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.bool.FALSE": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.bool.TRUE": {
+            "type": "const",
+            "value": 1
+        },
+        "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "x_and_y": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x_or_y": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "x_xor_y": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 5,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+            "members": {
+                "m": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "p": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 0
+                },
+                "q": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 2
+                },
+                "r": {
+                    "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                    "offset": 5
+                }
+            },
+            "size": 7,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.EcPoint": {
+            "destination": "starkware.cairo.common.ec_point.EcPoint",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "members": {
+                "result": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.KeccakBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.KeccakBuiltin",
+            "members": {
+                "input": {
+                    "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                    "offset": 0
+                },
+                "output": {
+                    "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                    "offset": 8
+                }
+            },
+            "size": 16,
+            "type": "struct"
+        },
+        "starkware.cairo.common.cairo_builtins.KeccakBuiltinState": {
+            "destination": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "type": "alias"
+        },
+        "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+            "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+            "members": {
+                "message": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "pub_key": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.ec_point.EcPoint": {
+            "full_name": "starkware.cairo.common.ec_point.EcPoint",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.HashBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.hash.hash2": {
+            "decorators": [],
+            "pc": 1,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash.hash2.Args": {
+            "full_name": "starkware.cairo.common.hash.hash2.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.hash2.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash.hash2.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash.hash2.Return": {
+            "cairo_type": "(result: felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash.hash2.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.hash.hash2.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash.hash2.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 1,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 3,
+                    "value": "cast([fp + (-5)] + 3, starkware.cairo.common.cairo_builtins.HashBuiltin*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.result": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 3,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.x": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 1,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash.hash2.y": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash.hash2.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 1,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.HashBuiltin": {
+            "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+            "type": "alias"
+        },
+        "starkware.cairo.common.hash_state.HashState": {
+            "full_name": "starkware.cairo.common.hash_state.HashState",
+            "members": {
+                "current_hash": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "n_words": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.get_fp_and_pc": {
+            "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+            "type": "alias"
+        },
+        "starkware.cairo.common.hash_state.hash2": {
+            "destination": "starkware.cairo.common.hash.hash2",
+            "type": "alias"
+        },
+        "starkware.cairo.common.hash_state.hash_felts": {
+            "decorators": [],
+            "pc": 91,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash_state.hash_felts.Args": {
+            "full_name": "starkware.cairo.common.hash_state.hash_felts.Args",
+            "members": {
+                "data": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "length": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_felts.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash_state.hash_felts.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_felts.Return": {
+            "cairo_type": "(hash: felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash_state.hash_felts.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.hash_state.hash_felts.data": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.hash_state.hash_felts.data",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 91,
+                    "value": "[cast(fp + (-4), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_felts.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash_state.hash_felts.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 91,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 0
+                    },
+                    "pc": 99,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 9
+                    },
+                    "pc": 101,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+            "full_name": "starkware.cairo.common.hash_state.hash_felts.hash_state_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 7
+                    },
+                    "pc": 93,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 0
+                    },
+                    "pc": 99,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_felts.length": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_felts.length",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 91,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_finalize": {
+            "decorators": [],
+            "pc": 60,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash_state.hash_finalize.Args": {
+            "full_name": "starkware.cairo.common.hash_state.hash_finalize.Args",
+            "members": {
+                "hash_state_ptr": {
+                    "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_finalize.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash_state.hash_finalize.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_finalize.Return": {
+            "cairo_type": "(hash: felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash_state.hash_finalize.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.hash_state.hash_finalize.hash": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_finalize.hash",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 7
+                    },
+                    "pc": 65,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_finalize.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash_state.hash_finalize.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 60,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 7
+                    },
+                    "pc": 65,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_finalize.hash_state_ptr": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+            "full_name": "starkware.cairo.common.hash_state.hash_finalize.hash_state_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 60,
+                    "value": "[cast(fp + (-3), starkware.cairo.common.hash_state.HashState**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_init": {
+            "decorators": [],
+            "pc": 7,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash_state.hash_init.Args": {
+            "full_name": "starkware.cairo.common.hash_state.hash_init.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_init.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash_state.hash_init.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_init.Return": {
+            "cairo_type": "(hash_state_ptr: starkware.cairo.common.hash_state.HashState*)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash_state.hash_init.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 2
+        },
+        "starkware.cairo.common.hash_state.hash_init.__fp__": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.hash_state.hash_init.__fp__",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 4
+                    },
+                    "pc": 11,
+                    "value": "[cast(ap + (-2), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_init.hash_state": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState",
+            "full_name": "starkware.cairo.common.hash_state.hash_init.hash_state",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 4
+                    },
+                    "pc": 11,
+                    "value": "[cast(fp, starkware.cairo.common.hash_state.HashState*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update": {
+            "decorators": [],
+            "pc": 17,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash_state.hash_update.Args": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update.Args",
+            "members": {
+                "data_length": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "data_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 1
+                },
+                "hash_state_ptr": {
+                    "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+                    "offset": 0
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update.Return": {
+            "cairo_type": "(new_hash_state_ptr: starkware.cairo.common.hash_state.HashState*)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash_state.hash_update.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 2
+        },
+        "starkware.cairo.common.hash_state.hash_update.__fp__": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update.__fp__",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "pc": 27,
+                    "value": "[cast(ap + (-2), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update.__temp0": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update.__temp0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "pc": 29,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update.data_length": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update.data_length",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update.data_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update.data_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-4), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update.hash": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update.hash",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 25,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 25,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update.hash_state_ptr": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update.hash_state_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.hash_state.HashState**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update.new_hash_state": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState",
+            "full_name": "starkware.cairo.common.hash_state.hash_update.new_hash_state",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "pc": 27,
+                    "value": "[cast(fp, starkware.cairo.common.hash_state.HashState*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner": {
+            "decorators": [],
+            "pc": 66,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.Args": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.Args",
+            "members": {
+                "data_length": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "data_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "hash": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.LoopLocals": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.LoopLocals",
+            "members": {
+                "cur_hash": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "data_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.Return": {
+            "cairo_type": "(hash: felt)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 1
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.__temp2": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.__temp2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 2
+                    },
+                    "pc": 75,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.__temp3": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.__temp3",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 7
+                    },
+                    "pc": 82,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.data_last_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 2
+                    },
+                    "pc": 76,
+                    "value": "[cast(fp, felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.data_length": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.data_length",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 66,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.data_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.data_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 66,
+                    "value": "[cast(fp + (-5), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.final_locals": {
+            "cairo_type": "starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.final_locals",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 10
+                    },
+                    "pc": 90,
+                    "value": "cast(ap + (-3), starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.first_locals": {
+            "cairo_type": "starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.first_locals",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 2
+                    },
+                    "pc": 76,
+                    "value": "cast(ap, starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.hash": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.hash",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 66,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.hash_loop": {
+            "pc": 79,
+            "type": "label"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 66,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 10
+                    },
+                    "pc": 90,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.n_remaining_elements",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 6
+                    },
+                    "pc": 80,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.next_locals": {
+            "cairo_type": "starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.next_locals",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 7
+                    },
+                    "pc": 83,
+                    "value": "cast(ap, starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_inner.prev_locals": {
+            "cairo_type": "starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_inner.prev_locals",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 5
+                    },
+                    "pc": 79,
+                    "value": "cast(ap + (-3), starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single": {
+            "decorators": [],
+            "pc": 33,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.Args": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.Args",
+            "members": {
+                "hash_state_ptr": {
+                    "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+                    "offset": 0
+                },
+                "item": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.Return": {
+            "cairo_type": "(new_hash_state_ptr: starkware.cairo.common.hash_state.HashState*)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 2
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.__fp__": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.__fp__",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 11
+                    },
+                    "pc": 42,
+                    "value": "[cast(ap + (-2), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.__temp1": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.__temp1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 12
+                    },
+                    "pc": 44,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.hash": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.hash",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 9
+                    },
+                    "pc": 40,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 33,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 9
+                    },
+                    "pc": 40,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.hash_state_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 33,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.hash_state.HashState**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.item": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.item",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 33,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_single.new_hash_state": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_single.new_hash_state",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 11
+                    },
+                    "pc": 42,
+                    "value": "[cast(fp, starkware.cairo.common.hash_state.HashState*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain": {
+            "decorators": [],
+            "pc": 49,
+            "type": "function"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.Args": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update_with_hashchain.Args",
+            "members": {
+                "data_length": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "data_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 1
+                },
+                "hash_state_ptr": {
+                    "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+                    "offset": 0
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.hash_state.hash_update_with_hashchain.ImplicitArgs",
+            "members": {
+                "hash_ptr": {
+                    "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.Return": {
+            "cairo_type": "(new_hash_state_ptr: starkware.cairo.common.hash_state.HashState*)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_length",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 49,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_with_hashchain.data_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 49,
+                    "value": "[cast(fp + (-4), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 54,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr": {
+            "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 49,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 54,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 19
+                    },
+                    "pc": 59,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr": {
+            "cairo_type": "starkware.cairo.common.hash_state.HashState*",
+            "full_name": "starkware.cairo.common.hash_state.hash_update_with_hashchain.hash_state_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 49,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.hash_state.HashState**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.keccak_state.KeccakBuiltinState": {
+            "full_name": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+            "members": {
+                "s0": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "s1": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                },
+                "s2": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "s3": {
+                    "cairo_type": "felt",
+                    "offset": 3
+                },
+                "s4": {
+                    "cairo_type": "felt",
+                    "offset": 4
+                },
+                "s5": {
+                    "cairo_type": "felt",
+                    "offset": 5
+                },
+                "s6": {
+                    "cairo_type": "felt",
+                    "offset": 6
+                },
+                "s7": {
+                    "cairo_type": "felt",
+                    "offset": 7
+                }
+            },
+            "size": 8,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math.FALSE": {
+            "destination": "starkware.cairo.common.bool.FALSE",
+            "type": "alias"
+        },
+        "starkware.cairo.common.math.TRUE": {
+            "destination": "starkware.cairo.common.bool.TRUE",
+            "type": "alias"
+        },
+        "starkware.cairo.common.math.assert_le_felt": {
+            "decorators": [
+                "known_ap_change"
+            ],
+            "pc": 102,
+            "type": "function"
+        },
+        "starkware.cairo.common.math.assert_le_felt.Args": {
+            "full_name": "starkware.cairo.common.math.assert_le_felt.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math.assert_le_felt.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.math.assert_le_felt.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math.assert_le_felt.PRIME_OVER_2_HIGH": {
+            "type": "const",
+            "value": 5316911983139663648412552867652567041
+        },
+        "starkware.cairo.common.math.assert_le_felt.PRIME_OVER_3_HIGH": {
+            "type": "const",
+            "value": 3544607988759775765608368578435044694
+        },
+        "starkware.cairo.common.math.assert_le_felt.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.math.assert_le_felt.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp10": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp10",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 10
+                    },
+                    "pc": 116,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp11": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp11",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 11
+                    },
+                    "pc": 117,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp12": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp12",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 12
+                    },
+                    "pc": 119,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp13": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp13",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 13
+                    },
+                    "pc": 121,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp14": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp14",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 14
+                    },
+                    "pc": 122,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp15": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp15",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 11
+                    },
+                    "pc": 130,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp16": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp16",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 13
+                    },
+                    "pc": 132,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp17": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp17",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 14
+                    },
+                    "pc": 134,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp18": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp18",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 11
+                    },
+                    "pc": 140,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp19": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp19",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 12
+                    },
+                    "pc": 141,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp4": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp4",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 1
+                    },
+                    "pc": 103,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp5": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp5",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 2
+                    },
+                    "pc": 104,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp6": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp6",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 3
+                    },
+                    "pc": 106,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp7": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp7",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 5
+                    },
+                    "pc": 108,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp8": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp8",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 6
+                    },
+                    "pc": 109,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.__temp9": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.__temp9",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 7
+                    },
+                    "pc": 111,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.a": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 102,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.arc_long": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.arc_long",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 8
+                    },
+                    "pc": 112,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.arc_prod": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.arc_prod",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 8
+                    },
+                    "pc": 112,
+                    "value": "cast([ap + (-5)] * [ap + (-1)], felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.arc_short": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.arc_short",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 4
+                    },
+                    "pc": 107,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.arc_sum": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.arc_sum",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 8
+                    },
+                    "pc": 112,
+                    "value": "cast([ap + (-5)] + [ap + (-1)], felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.b": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 102,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.m1mb": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.m1mb",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 12
+                    },
+                    "pc": 131,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_le_felt.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 102,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 8
+                    },
+                    "pc": 112,
+                    "value": "cast([fp + (-5)] + 4, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_le_felt.skip_exclude_a": {
+            "pc": 126,
+            "type": "label"
+        },
+        "starkware.cairo.common.math.assert_le_felt.skip_exclude_b_minus_a": {
+            "pc": 138,
+            "type": "label"
+        },
+        "starkware.cairo.common.math.assert_lt_felt": {
+            "decorators": [
+                "known_ap_change"
+            ],
+            "pc": 147,
+            "type": "function"
+        },
+        "starkware.cairo.common.math.assert_lt_felt.Args": {
+            "full_name": "starkware.cairo.common.math.assert_lt_felt.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math.assert_lt_felt.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.math.assert_lt_felt.ImplicitArgs",
+            "members": {
+                "range_check_ptr": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.math.assert_lt_felt.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.math.assert_lt_felt.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.math.assert_lt_felt.__temp20": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_lt_felt.__temp20",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 1
+                    },
+                    "pc": 148,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_lt_felt.a": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_lt_felt.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "pc": 147,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_lt_felt.b": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_lt_felt.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "pc": 147,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.math.assert_lt_felt.range_check_ptr": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.math.assert_lt_felt.range_check_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "pc": 147,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 21
+                    },
+                    "pc": 157,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.registers.get_ap": {
+            "destination": "starkware.cairo.lang.compiler.lib.registers.get_ap",
+            "type": "alias"
+        },
+        "starkware.cairo.common.registers.get_fp_and_pc": {
+            "destination": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc",
+            "type": "alias"
+        },
+        "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Args": {
+            "full_name": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.ImplicitArgs": {
+            "full_name": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.Return": {
+            "cairo_type": "(fp_val: felt*, pc_val: felt*)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 1,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 1,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 1,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 3,
+                "value": "[cast([fp + (-5)] + 2, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 3,
+                "value": "cast([fp + (-5)] + 3, starkware.cairo.common.cairo_builtins.HashBuiltin*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 4
+                },
+                "pc": 11,
+                "value": "[cast(ap + (-2), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 4
+                },
+                "pc": 11,
+                "value": "[cast(fp, starkware.cairo.common.hash_state.HashState*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-5), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 25,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 25,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 2
+                },
+                "pc": 27,
+                "value": "[cast(ap + (-2), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 2
+                },
+                "pc": 27,
+                "value": "[cast(fp, starkware.cairo.common.hash_state.HashState*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 3
+                },
+                "pc": 29,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 33,
+                "value": "[cast(fp + (-4), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 33,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 33,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 9
+                },
+                "pc": 40,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 9
+                },
+                "pc": 40,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 11
+                },
+                "pc": 42,
+                "value": "[cast(ap + (-2), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 11
+                },
+                "pc": 42,
+                "value": "[cast(fp, starkware.cairo.common.hash_state.HashState*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 12
+                },
+                "pc": 44,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 49,
+                "value": "[cast(fp + (-5), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 49,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 49,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 6,
+                    "offset": 0
+                },
+                "pc": 49,
+                "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 54,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 0
+                },
+                "pc": 54,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 7,
+                    "offset": 19
+                },
+                "pc": 59,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 60,
+                "value": "[cast(fp + (-3), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 0
+                },
+                "pc": 60,
+                "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 7
+                },
+                "pc": 65,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 8,
+                    "offset": 7
+                },
+                "pc": 65,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 66,
+                "value": "[cast(fp + (-5), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 66,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 66,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 0
+                },
+                "pc": 66,
+                "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 2
+                },
+                "pc": 75,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 2
+                },
+                "pc": 76,
+                "value": "[cast(fp, felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 2
+                },
+                "pc": 76,
+                "value": "cast(ap, starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 5
+                },
+                "pc": 79,
+                "value": "cast(ap + (-3), starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 6
+                },
+                "pc": 80,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 7
+                },
+                "pc": 82,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 7
+                },
+                "pc": 83,
+                "value": "cast(ap, starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 10
+                },
+                "pc": 90,
+                "value": "cast(ap + (-3), starkware.cairo.common.hash_state.hash_update_inner.LoopLocals*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 9,
+                    "offset": 10
+                },
+                "pc": 90,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 0
+                },
+                "pc": 91,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 0
+                },
+                "pc": 91,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 0
+                },
+                "pc": 91,
+                "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 10,
+                    "offset": 7
+                },
+                "pc": 93,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 11,
+                    "offset": 0
+                },
+                "pc": 99,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 11,
+                    "offset": 0
+                },
+                "pc": 99,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 11,
+                    "offset": 9
+                },
+                "pc": 101,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 0
+                },
+                "pc": 102,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 0
+                },
+                "pc": 102,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 0
+                },
+                "pc": 102,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 1
+                },
+                "pc": 103,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 2
+                },
+                "pc": 104,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 3
+                },
+                "pc": 106,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 4
+                },
+                "pc": 107,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 5
+                },
+                "pc": 108,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 6
+                },
+                "pc": 109,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 7
+                },
+                "pc": 111,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 8
+                },
+                "pc": 112,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 8
+                },
+                "pc": 112,
+                "value": "cast([fp + (-5)] + 4, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 8
+                },
+                "pc": 112,
+                "value": "cast([ap + (-5)] + [ap + (-1)], felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 8
+                },
+                "pc": 112,
+                "value": "cast([ap + (-5)] * [ap + (-1)], felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 10
+                },
+                "pc": 116,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 11
+                },
+                "pc": 117,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 12
+                },
+                "pc": 119,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 13
+                },
+                "pc": 121,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 14
+                },
+                "pc": 122,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 11
+                },
+                "pc": 130,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 12
+                },
+                "pc": 131,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 13
+                },
+                "pc": 132,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 14
+                },
+                "pc": 134,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 11
+                },
+                "pc": 140,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 12,
+                    "offset": 12
+                },
+                "pc": 141,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 13,
+                    "offset": 0
+                },
+                "pc": 147,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 13,
+                    "offset": 0
+                },
+                "pc": 147,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 13,
+                    "offset": 0
+                },
+                "pc": 147,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 13,
+                    "offset": 1
+                },
+                "pc": 148,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 13,
+                    "offset": 21
+                },
+                "pc": 157,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 14,
+                    "offset": 0
+                },
+                "pc": 158,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 14,
+                    "offset": 0
+                },
+                "pc": 158,
+                "value": "[cast(fp + (-3), __main__.ContractEntryPoint**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 14,
+                    "offset": 0
+                },
+                "pc": 158,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 15,
+                    "offset": 0
+                },
+                "pc": 170,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 16,
+                    "offset": 0
+                },
+                "pc": 171,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 16,
+                    "offset": 0
+                },
+                "pc": 171,
+                "value": "[cast(fp + (-4), __main__.ContractEntryPoint**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 16,
+                    "offset": 0
+                },
+                "pc": 171,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 16,
+                    "offset": 0
+                },
+                "pc": 171,
+                "value": "[cast(fp + (-6), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 16,
+                    "offset": 26
+                },
+                "pc": 180,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 17,
+                    "offset": 0
+                },
+                "pc": 187,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 18,
+                    "offset": 0
+                },
+                "pc": 188,
+                "value": "[cast(fp + (-3), __main__.ContractClass**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 18,
+                    "offset": 0
+                },
+                "pc": 188,
+                "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 18,
+                    "offset": 7
+                },
+                "pc": 190,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 18,
+                    "offset": 26
+                },
+                "pc": 195,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 18,
+                    "offset": 26
+                },
+                "pc": 195,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 18,
+                    "offset": 27
+                },
+                "pc": 196,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 19,
+                    "offset": 0
+                },
+                "pc": 203,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 19,
+                    "offset": 0
+                },
+                "pc": 203,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 19,
+                    "offset": 1
+                },
+                "pc": 204,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 20,
+                    "offset": 0
+                },
+                "pc": 211,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 20,
+                    "offset": 0
+                },
+                "pc": 211,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 20,
+                    "offset": 1
+                },
+                "pc": 212,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 21,
+                    "offset": 0
+                },
+                "pc": 219,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 21,
+                    "offset": 0
+                },
+                "pc": 219,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 22,
+                    "offset": 0
+                },
+                "pc": 223,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 22,
+                    "offset": 0
+                },
+                "pc": 223,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 22,
+                    "offset": 17
+                },
+                "pc": 226,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 22,
+                    "offset": 17
+                },
+                "pc": 226,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 23,
+                    "offset": 0
+                },
+                "pc": 230,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 23,
+                    "offset": 0
+                },
+                "pc": 230,
+                "value": "[cast(ap + (-1), starkware.cairo.common.hash_state.HashState**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 23,
+                    "offset": 9
+                },
+                "pc": 232,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 23,
+                    "offset": 9
+                },
+                "pc": 232,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 24,
+                    "offset": 0
+                },
+                "pc": 233,
+                "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 24,
+                    "offset": 0
+                },
+                "pc": 233,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 24,
+                    "offset": 2
+                },
+                "pc": 235,
+                "value": "[cast(fp, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 24,
+                    "offset": 2
+                },
+                "pc": 235,
+                "value": "[cast(fp + 1, __main__.ContractClassFact**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 25,
+                    "offset": 0
+                },
+                "pc": 241,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 25,
+                    "offset": 0
+                },
+                "pc": 241,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 0
+                },
+                "pc": 244,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 0
+                },
+                "pc": 244,
+                "value": "[cast(fp + (-3), __main__.ContractClassFact**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 0
+                },
+                "pc": 244,
+                "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 0
+                },
+                "pc": 244,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 1
+                },
+                "pc": 251,
+                "value": "[cast(fp + (-3), __main__.ContractClassFact**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 1
+                },
+                "pc": 251,
+                "value": "[cast([fp + (-3)] + 1, __main__.ContractClass**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 2
+                },
+                "pc": 252,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 3
+                },
+                "pc": 254,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 4
+                },
+                "pc": 256,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 26,
+                    "offset": 5
+                },
+                "pc": 257,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 27,
+                    "offset": 0
+                },
+                "pc": 262,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 27,
+                    "offset": 1
+                },
+                "pc": 263,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 27,
+                    "offset": 2
+                },
+                "pc": 264,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 28,
+                    "offset": 0
+                },
+                "pc": 269,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 28,
+                    "offset": 0
+                },
+                "pc": 270,
+                "value": "[cast(fp, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 29,
+                    "offset": 0
+                },
+                "pc": 274,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 29,
+                    "offset": 0
+                },
+                "pc": 274,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 30,
+                    "offset": 0
+                },
+                "pc": 283,
+                "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 30,
+                    "offset": 0
+                },
+                "pc": 283,
+                "value": "[cast(ap + (-1), felt*)]"
+            }
+        ]
+    }
+}

--- a/sequencer/src/abci/application.rs
+++ b/sequencer/src/abci/application.rs
@@ -171,7 +171,7 @@ impl Application for StarknetApp {
                         events.push(function_event);
                     }
                     TransactionType::Declare { program } => {
-                        let contract_class = ContractClass::try_from(program.to_string()).expect("Could not load contract from JSON");
+                        let contract_class = ContractClass::try_from(program.to_string()).expect("Could not load contract from payload");
                         self.starknet_state.lock().map(|mut state| state.declare(contract_class).unwrap()).unwrap();
                         // TODO: Should we send an event about this?
                     },

--- a/sequencer/src/abci/application.rs
+++ b/sequencer/src/abci/application.rs
@@ -6,7 +6,9 @@ use std::{
 use lib::{Transaction, TransactionType};
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
-use starknet_rs::{testing::starknet_state::StarknetState, services::api::contract_class::ContractClass};
+use starknet_rs::{
+    services::api::contract_class::ContractClass, testing::starknet_state::StarknetState,
+};
 use tendermint_abci::Application;
 use tendermint_proto::abci;
 
@@ -171,10 +173,14 @@ impl Application for StarknetApp {
                         events.push(function_event);
                     }
                     TransactionType::Declare { program } => {
-                        let contract_class = ContractClass::try_from(program.to_string()).expect("Could not load contract from payload");
-                        self.starknet_state.lock().map(|mut state| state.declare(contract_class).unwrap()).unwrap();
+                        let contract_class = ContractClass::try_from(program)
+                            .expect("Could not load contract from payload");
+                        self.starknet_state
+                            .lock()
+                            .map(|mut state| state.declare(contract_class).unwrap())
+                            .unwrap();
                         // TODO: Should we send an event about this?
-                    },
+                    }
                     TransactionType::Deploy => todo!(),
                     TransactionType::Invoke => todo!(),
                 }

--- a/sequencer/src/cli/main.rs
+++ b/sequencer/src/cli/main.rs
@@ -105,7 +105,7 @@ async fn do_declare(args: DeclareArgs) -> (i32, String) {
     let transaction = Transaction::with_type(transaction_type).unwrap();
     let transaction_serialized = bincode::serialize(&transaction).unwrap();
     match broadcast(transaction_serialized, LOCAL_SEQUENCER_URL).await {
-        Ok(_) => (0, format!("DECLARE: Sent transaction")),
+        Ok(_) => (0, format!("Sent DECLARE transaction (ID {}) succesfully. Hash: {}", transaction.id, transaction.transaction_hash)),
         Err(e) => (1, format!("DECLARE: Error sending out transaction: {}", e)),
     }
 }

--- a/sequencer/src/cli/main.rs
+++ b/sequencer/src/cli/main.rs
@@ -99,8 +99,15 @@ async fn do_execute(args: ExecuteArgs) -> (i32, String) {
     }
 }
 
-async fn do_declare(_args: DeclareArgs) -> (i32, String) {
-    todo!()
+async fn do_declare(args: DeclareArgs) -> (i32, String) {
+    let program = fs::read_to_string(args.contract).unwrap();
+    let transaction_type = TransactionType::Declare { program };
+    let transaction = Transaction::with_type(transaction_type).unwrap();
+    let transaction_serialized = bincode::serialize(&transaction).unwrap();
+    match broadcast(transaction_serialized, LOCAL_SEQUENCER_URL).await {
+        Ok(_) => (0, format!("DECLARE: Sent transaction")),
+        Err(e) => (1, format!("DECLARE: Error sending out transaction: {}", e)),
+    }
 }
 
 async fn do_deploy(_args: DeployArgs) -> (i32, String) {

--- a/sequencer/src/cli/main.rs
+++ b/sequencer/src/cli/main.rs
@@ -105,7 +105,13 @@ async fn do_declare(args: DeclareArgs) -> (i32, String) {
     let transaction = Transaction::with_type(transaction_type).unwrap();
     let transaction_serialized = bincode::serialize(&transaction).unwrap();
     match broadcast(transaction_serialized, LOCAL_SEQUENCER_URL).await {
-        Ok(_) => (0, format!("Sent DECLARE transaction (ID {}) succesfully. Hash: {}", transaction.id, transaction.transaction_hash)),
+        Ok(_) => (
+            0,
+            format!(
+                "Sent DECLARE transaction (ID {}) succesfully. Hash: {}",
+                transaction.id, transaction.transaction_hash
+            ),
+        ),
         Err(e) => (1, format!("DECLARE: Error sending out transaction: {}", e)),
     }
 }

--- a/sequencer/src/lib/mod.rs
+++ b/sequencer/src/lib/mod.rs
@@ -25,7 +25,9 @@ pub struct Transaction {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum TransactionType {
     /// Create new contract class.
-    Declare,
+    Declare {
+        program: String,
+    },
 
     /// Create an instance of a contract which will have storage assigned. (Accounts are a contract themselves)
     Deploy,
@@ -126,7 +128,11 @@ impl TransactionType {
                 let hash = hasher.finalize().as_slice().to_owned();
                 Ok(hex::encode(hash))
             }
-            TransactionType::Declare => todo!(),
+            TransactionType::Declare { program } => {
+                let contract_class = ContractClass::try_from(program.to_string()).expect("Could not load contract from JSON");
+                let contract_hash = starknet_rs::core::contract_address::starknet_contract_address::compute_class_hash(&contract_class).unwrap();
+                Ok(hex::encode(contract_hash.to_bytes_be()))
+            },
             TransactionType::Deploy => todo!(),
             TransactionType::Invoke => todo!(),
         }

--- a/sequencer/src/lib/mod.rs
+++ b/sequencer/src/lib/mod.rs
@@ -130,6 +130,7 @@ impl TransactionType {
             }
             TransactionType::Declare { program } => {
                 let contract_class = ContractClass::try_from(program.to_string()).expect("Could not load contract from JSON");
+                // This function requires cairo_programs/contracts.json to exist as it uses that cairo program to compute the hash
                 let contract_hash = starknet_rs::core::contract_address::starknet_contract_address::compute_class_hash(&contract_class).unwrap();
                 Ok(hex::encode(contract_hash.to_bytes_be()))
             },

--- a/sequencer/src/lib/mod.rs
+++ b/sequencer/src/lib/mod.rs
@@ -25,9 +25,7 @@ pub struct Transaction {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum TransactionType {
     /// Create new contract class.
-    Declare {
-        program: String,
-    },
+    Declare { program: String },
 
     /// Create an instance of a contract which will have storage assigned. (Accounts are a contract themselves)
     Deploy,
@@ -129,11 +127,12 @@ impl TransactionType {
                 Ok(hex::encode(hash))
             }
             TransactionType::Declare { program } => {
-                let contract_class = ContractClass::try_from(program.to_string()).expect("Could not load contract from JSON");
+                let contract_class = ContractClass::try_from(program.to_string())
+                    .expect("Could not load contract from JSON");
                 // This function requires cairo_programs/contracts.json to exist as it uses that cairo program to compute the hash
                 let contract_hash = starknet_rs::core::contract_address::starknet_contract_address::compute_class_hash(&contract_class).unwrap();
                 Ok(hex::encode(contract_hash.to_bytes_be()))
-            },
+            }
             TransactionType::Deploy => todo!(),
             TransactionType::Invoke => todo!(),
         }


### PR DESCRIPTION
This adds support for `declare` type of transactions.

One caveat it currently has is that starknet_in_rust `compute_class_hash` requires the file `cairo_programs/contracts.json` to exist as it uses that cairo program to compute the hash

To send this transaction in our CLI you would do
```
cargo run --release declare --contract <your_contract.json>
```